### PR TITLE
Fix 404 from branch protection jobs

### DIFF
--- a/.github/workflows/fetch-quickstarts.yml
+++ b/.github/workflows/fetch-quickstarts.yml
@@ -43,12 +43,12 @@ jobs:
 
       - name: Temporarily disable branch protection
         id: disable-branch-protection
-        uses: actions/github-script@v1
+        uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'main',
@@ -78,12 +78,12 @@ jobs:
       - name: Re-enable branch protection
         id: enable-branch-protection
         if: always()
-        uses: actions/github-script@v1
+        uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'main',


### PR DESCRIPTION
## Summary
* github-script v1 was getting a 404 for the branch protection endpoint
* upgraded github-script to v5
* updated calls for breaking changes