### PR TITLE
Swap cookie used for user logged in check

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -41,7 +41,7 @@ const checkUtmParameters = (parameters) => {
  * @returns {Boolean}
  */
 const checkIfReturningUser = () => {
-  return Boolean(Cookies.get('ajs_user_id'));
+  return Boolean(Cookies.get('login_service_login_newrelic_com_tokens'));
 };
 
 /**


### PR DESCRIPTION
## Summary
Swap cookie used in user logged in check from `ajs_user_id` -> `login_service_login_newrelic_com_tokens`

Our working theory was that `ajs_user_id` is set after / during tessen calls, and when users have ad blocker or privacy extensions, the `ajs_user_id` cookie isn't set. This shouldn't happen as frequently (if at all) with the new token, so we expect this new token to work better for determining if someone is a returning user.

## Links
Relates to: #32