### PR TITLE
Remove cookie based signup logic

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -37,14 +37,6 @@ const checkUtmParameters = (parameters) => {
 };
 
 /**
- * Method which returns `false` if current user is 'new'. Returns `true` if user is a returning user.
- * @returns {Boolean}
- */
-const checkIfReturningUser = () => {
-  return Boolean(Cookies.get('ajs_user_id'));
-};
-
-/**
  * @param {String} id
  * @param {String} nerdletId
  * @param {Boolean} hasGuidedInstall
@@ -57,14 +49,13 @@ const createInstallLink = (
   nerdletId,
   hasGuidedInstall,
   hasUtmParameters,
-  isReturningUser,
   parameters
 ) => {
   const platformUrl = hasGuidedInstall
     ? getGuidedInstallStackedNr1Url(nerdletId)
     : getPackNr1Url(id, nerdletId);
 
-  const installUrl = new URL(isReturningUser ? platformUrl : SIGNUP_LINK);
+  const installUrl = new URL(platformUrl);
   if (parameters) {
     parameters.forEach((value, key) => {
       installUrl.searchParams.set(key, value);
@@ -134,7 +125,6 @@ const InstallButton = ({ quickstart, location, ...props }) => {
         nerdletId,
         hasGuidedInstall,
         hasUtmParameters,
-        checkIfReturningUser(),
         parameters
       )
     : quickstart.documentation[0].url;


### PR DESCRIPTION
## Summary
* Remove logic to check for a cookie to determine if the install link
  should go to the platform or the signup url
* All install links will now go directly to the platform