### PR TITLE
feat: create 500 error page

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/Layout/Layout.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/Layout/Layout.js
@@ -16,8 +16,7 @@ const Layout = ({ className, children }) => {
 
         display: grid;
         grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
-        grid-template-areas:
-          'sidebar main'
+        grid-template-areas: 'sidebar main';
         grid-template-rows: 1fr auto;
         min-height: calc(100vh - var(--global-header-height));
         margin: 0 auto;
@@ -25,8 +24,7 @@ const Layout = ({ className, children }) => {
 
         @media screen and (max-width: 760px) {
           grid-template-columns: minmax(0, 1fr);
-          grid-template-areas:
-            'main'
+          grid-template-areas: 'main';
           grid-template-rows: unset;
         }
       `}

--- a/src/pages/500.js
+++ b/src/pages/500.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Callout,
+  GlobalHeader,
+  GlobalFooter,
+  Layout as ThemeLayout,
+  NR_SITES,
+} from '@newrelic/gatsby-theme-newrelic';
+import { css } from '@emotion/react';
+import GuidedInstallTile from './../components/GuidedInstallTile';
+import IOLogo from '../components/IOLogo';
+import '../components/styles.scss';
+import { QUICKSTARTS_COLLAPSE_BREAKPOINT } from '../data/constants';
+
+const FivehundredErrorPage = () => {
+  return (
+    <>
+      <GlobalHeader activeSite={NR_SITES.IO} />
+      <ThemeLayout>
+        <ThemeLayout.Sidebar
+          css={css`
+            grid-area: sidebar;
+          `}
+        >
+          <IOLogo />
+          <p>
+            A place to find quickstarts of resources like dashboards,
+            instrumentation, and alerts to help you monitor your environment.
+          </p>
+        </ThemeLayout.Sidebar>
+        <ThemeLayout.Main
+          css={css`
+            grid-area: main;
+            padding: 72px 100px 0;
+            margin: 0 auto;
+          `}
+        >
+          <div
+            css={css`
+              padding-bottom: 36px;
+            `}
+          >
+            <Callout variant={Callout.VARIANT.IMPORTANT}>
+              We are currently experiencing technical issues loading the Instant
+              Observability catalog. Please use the guided install tile below to
+              start the install process.
+            </Callout>
+          </div>
+          <div
+            css={css`
+              width: 100%;
+              max-width: 600px;
+              margin: 0 auto;
+            `}
+          >
+            <GuidedInstallTile />
+          </div>
+        </ThemeLayout.Main>
+      </ThemeLayout>
+      <GlobalFooter
+        css={css`
+          max-width: 100% @media screen and
+            (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+            margin-left: 0;
+          }
+        `}
+      />
+    </>
+  );
+};
+
+export default FivehundredErrorPage;


### PR DESCRIPTION
Following the mockup in the ticket, this PR creates a 500 error page for the IO site. 

- It displays at `localhost:8000/500` with a `yarn develop`. I seems to work fine in mobile view.
- I am unsure how to test if it works when the catalog service fails. 


<img width="1303" alt="Screen Shot 2022-03-02 at 11 32 58 AM" src="https://user-images.githubusercontent.com/47728020/156439729-66003961-7635-451d-be87-6027c319c1ce.png">
<img width="288" alt="Screen Shot 2022-03-02 at 11 52 37 AM" src="https://user-images.githubusercontent.com/47728020/156439734-a362de99-5e2c-4027-9539-95e071bd89b4.png">

closes https://github.com/newrelic/instant-observability-website/issues/46