### PR TITLE
chore: CXPUI-28 chore updated quick start json and removed sorting ba…

### DIFF
--- a/src/data/quickstarts.json
+++ b/src/data/quickstarts.json
@@ -822,8 +822,7 @@
       "aws",
       "amazon web services",
       "os",
-      "operating system",
-      "most popular"
+      "operating system"
     ],
     "level": "NEWRELIC",
     "logoUrl": "https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/v0.112.1/quickstarts/aws/amazon-linux/logo.svg",
@@ -12421,7 +12420,7 @@
     "keywords": [
       "os",
       "operating system",
-      "featured"
+      "most popular"
     ],
     "level": "NEWRELIC",
     "logoUrl": "https://raw.githubusercontent.com/newrelic/newrelic-quickstarts/v0.112.1/quickstarts/linux/logo.svg",

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -149,7 +149,8 @@ const QuickstartsPage = ({ data, location }) => {
   );
 
   const alphaSort = quickstarts.sort((a, b) => a.title.localeCompare(b.title));
-  let sortedQuickstarts = sortFeaturedQuickstarts(alphaSort);
+  //let sortedQuickstarts = sortFeaturedQuickstarts(alphaSort);
+  let sortedQuickstarts = alphaSort;
 
   // Hard-code for moving codestream object to front of sortedQuickstarts array - CM
   if ((!category && !search) || (category === 'featured' && !search)) {


### PR DESCRIPTION
1. removed featured key word based sorting as the featured carousel and the tiles below featured carousel are same.
2. updated most popular keyword in json for replacing amazon linux to linux 