### PR TITLE
CXPUI-26:hidden the carousel when user select the category

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -88,6 +88,7 @@ const QuickstartsPage = ({ data, location }) => {
 
   const [isCategoriesOverlayOpen, setIsCategoriesOverlayOpen] = useState(false);
   const [isSearchInputEmpty, setIsSearchInputEmpty] = useState(true);
+  const [isSelectCategory, setIsSelectCategory] = useState(false)
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -120,13 +121,15 @@ const QuickstartsPage = ({ data, location }) => {
   };
 
   const handleCategory = (value) => {
+    setIsSelectCategory(true);
     if (value !== null && value !== undefined) {
       const params = new URLSearchParams(location.search);
       params.set('category', value);
-
       navigate(`?${params.toString()}`);
+      if(value!=""){
+        setIsSelectCategory(false);
+      }
     }
-
     closeCategoriesOverlay();
   };
 
@@ -426,7 +429,8 @@ const QuickstartsPage = ({ data, location }) => {
             </Overlay>
           </div>
 
-          {isSearchInputEmpty && (
+          {isSelectCategory && (
+      
             <>
               {mostPopularQuickStarts.length > 0 && (
                 <>
@@ -650,7 +654,7 @@ const QuickstartsPage = ({ data, location }) => {
               `};
             `}
           >
-            {!isSearchInputEmpty && <SuperTiles />}
+            {!isSearchInputEmpty  && <SuperTiles />}
             {filteredQuickstarts.map((pack) => (
               <QuickstartTile
                 key={pack.id}
@@ -659,6 +663,7 @@ const QuickstartsPage = ({ data, location }) => {
                 {...pack}
               />
             ))}
+               
           </div>
         </div>
       </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -88,7 +88,7 @@ const QuickstartsPage = ({ data, location }) => {
 
   const [isCategoriesOverlayOpen, setIsCategoriesOverlayOpen] = useState(false);
   const [isSearchInputEmpty, setIsSearchInputEmpty] = useState(true);
-  const [isSelectCategory, setIsSelectCategory] = useState(false)
+  const [isSelectCategory, setIsSelectCategory] = useState(true);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -126,7 +126,7 @@ const QuickstartsPage = ({ data, location }) => {
       const params = new URLSearchParams(location.search);
       params.set('category', value);
       navigate(`?${params.toString()}`);
-      if(value!=""){
+      if (value != '') {
         setIsSelectCategory(false);
       }
     }
@@ -430,10 +430,93 @@ const QuickstartsPage = ({ data, location }) => {
           </div>
 
           {isSelectCategory && (
-      
             <>
-              {mostPopularQuickStarts.length > 0 && (
+              {isSearchInputEmpty && (
                 <>
+                  {mostPopularQuickStarts.length > 0 && (
+                    <>
+                      <div
+                        css={css`
+                          --text-color: var(--primary-text-color);
+                          font-size: 16px;
+                          color: var(--color-neutrals-800);
+                          align-text: center;
+                          span {
+                            color: var(--text-color);
+                            /* target inner children of parent span */
+                            span,
+                            strong {
+                              @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+                                display: none;
+                              }
+                            }
+                          }
+                          strong {
+                            color: var(--text-color);
+                          }
+                          @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+                            padding: 0 0 0.5rem;
+                          }
+                        `}
+                      >
+                        <span>
+                          <strong>Most Popular</strong>
+                        </span>
+                      </div>
+                      <div
+                        css={css`
+                          display: block;
+                          grid-gap: 1.25rem;
+                          padding: 10px;
+                          grid-template-columns: repeat(4, 1fr);
+                          grid-auto-rows: 1fr;
+                          ${view === VIEWS.GRID &&
+                          css`
+                            @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
+                              grid-template-columns: repeat(3, 1fr);
+                            }
+                            @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
+                              grid-template-columns: repeat(2, 1fr);
+                            }
+                            @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
+                              grid-template-columns: repeat(1, 1fr);
+                            }
+                          `}
+                          ${view === VIEWS.LIST &&
+                          css`
+                            grid-auto-rows: 1fr;
+                            grid-template-columns: 1fr;
+                            grid-gap: 1.25rem;
+                          `};
+                        `}
+                      >
+                        <Slider
+                          {...settings}
+                          css={css`
+                            display: flex;
+                          `}
+                        >
+                          <SuperTiles />
+                          {mostPopularQuickStarts.map((pack) => (
+                            <QuickstartTile
+                              key={pack.id}
+                              view={view}
+                              featured={false}
+                              css={css`
+                                grid-template-rows:
+                                  var(--tile-image-height) var(
+                                    --title-row-height
+                                  )
+                                  80px auto;
+                                min-height: 280px;
+                              `}
+                              {...pack}
+                            />
+                          ))}
+                        </Slider>
+                      </div>
+                    </>
+                  )}
                   <div
                     css={css`
                       --text-color: var(--primary-text-color);
@@ -459,14 +542,14 @@ const QuickstartsPage = ({ data, location }) => {
                     `}
                   >
                     <span>
-                      <strong>Most Popular</strong>
+                      <strong>Featured</strong>
                     </span>
                   </div>
                   <div
                     css={css`
                       display: block;
-                      grid-gap: 1.25rem;
                       padding: 10px;
+                      grid-gap: 1.25rem;
                       grid-template-columns: repeat(4, 1fr);
                       grid-auto-rows: 1fr;
                       ${view === VIEWS.GRID &&
@@ -489,14 +572,8 @@ const QuickstartsPage = ({ data, location }) => {
                       `};
                     `}
                   >
-                    <Slider
-                      {...settings}
-                      css={css`
-                        display: flex;
-                      `}
-                    >
-                      <SuperTiles />
-                      {mostPopularQuickStarts.map((pack) => (
+                    <Slider {...settings}>
+                      {featuredQuickStarts.map((pack) => (
                         <QuickstartTile
                           key={pack.id}
                           view={view}
@@ -514,78 +591,6 @@ const QuickstartsPage = ({ data, location }) => {
                   </div>
                 </>
               )}
-              <div
-                css={css`
-                  --text-color: var(--primary-text-color);
-                  font-size: 16px;
-                  color: var(--color-neutrals-800);
-                  align-text: center;
-                  span {
-                    color: var(--text-color);
-                    /* target inner children of parent span */
-                    span,
-                    strong {
-                      @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-                        display: none;
-                      }
-                    }
-                  }
-                  strong {
-                    color: var(--text-color);
-                  }
-                  @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-                    padding: 0 0 0.5rem;
-                  }
-                `}
-              >
-                <span>
-                  <strong>Featured</strong>
-                </span>
-              </div>
-              <div
-                css={css`
-                  display: block;
-                  padding: 10px;
-                  grid-gap: 1.25rem;
-                  grid-template-columns: repeat(4, 1fr);
-                  grid-auto-rows: 1fr;
-                  ${view === VIEWS.GRID &&
-                  css`
-                    @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
-                      grid-template-columns: repeat(3, 1fr);
-                    }
-                    @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
-                      grid-template-columns: repeat(2, 1fr);
-                    }
-                    @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
-                      grid-template-columns: repeat(1, 1fr);
-                    }
-                  `}
-                  ${view === VIEWS.LIST &&
-                  css`
-                    grid-auto-rows: 1fr;
-                    grid-template-columns: 1fr;
-                    grid-gap: 1.25rem;
-                  `};
-                `}
-              >
-                <Slider {...settings}>
-                  {featuredQuickStarts.map((pack) => (
-                    <QuickstartTile
-                      key={pack.id}
-                      view={view}
-                      featured={false}
-                      css={css`
-                        grid-template-rows:
-                          var(--tile-image-height) var(--title-row-height)
-                          80px auto;
-                        min-height: 280px;
-                      `}
-                      {...pack}
-                    />
-                  ))}
-                </Slider>
-              </div>
             </>
           )}
           <div
@@ -654,7 +659,7 @@ const QuickstartsPage = ({ data, location }) => {
               `};
             `}
           >
-            {!isSearchInputEmpty  && <SuperTiles />}
+            {!isSearchInputEmpty && <SuperTiles />}
             {filteredQuickstarts.map((pack) => (
               <QuickstartTile
                 key={pack.id}
@@ -663,7 +668,6 @@ const QuickstartsPage = ({ data, location }) => {
                 {...pack}
               />
             ))}
-               
           </div>
         </div>
       </div>


### PR DESCRIPTION
JIRA: https://newrelic.atlassian.net/browse/CXPUI-26
Description: When user selects a category in left navigation panel carousel of most popular and featured are supposed to be hidden
OLD VIEW: 
when all option selected in left panel
<img width="1428" alt="Screenshot 2022-03-03 at 9 10 04 PM" src="https://user-images.githubusercontent.com/99384747/156598805-eec49e34-f7e9-48c7-8ed5-323d0d96602e.png">
when any category is selected
<img width="1386" alt="Screenshot 2022-03-03 at 9 10 37 PM" src="https://user-images.githubusercontent.com/99384747/156598898-2507b8b5-4df7-498a-87a3-535942db798d.png">
NEW VIEW:
when all option is selected
<img width="1417" alt="Screenshot 2022-03-03 at 9 06 01 PM" src="https://user-images.githubusercontent.com/99384747/156599121-c39150c1-327e-40ff-9c53-8041a0af2735.png">
when any category selected
<img width="1433" alt="Screenshot 2022-03-03 at 9 06 12 PM" src="https://user-images.githubusercontent.com/99384747/156599226-e9b7f09c-3044-4b27-a5bb-79094680c7e9.png">

