### PR TITLE
chore: CXPUI-22 chore tiles in overview as clickable

### DIFF
--- a/src/components/OverviewTile.js
+++ b/src/components/OverviewTile.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
-import { Surface, Tag } from '@newrelic/gatsby-theme-newrelic';
+import { Link, Surface, Tag } from '@newrelic/gatsby-theme-newrelic';
+import useTabs from './Tabs/useTabs';
 
 const truncateDescription = (description) => {
   if (description.length > 250) {
@@ -13,12 +14,33 @@ const truncateDescription = (description) => {
 };
 
 const OverviewTile = ({ key, title, image, description, tag }) => {
+  const [currentTab, setCurrentTab] = useTabs();
+
+  const navigateToTab = (tag) => {
+    switch (tag) {
+      case 'Dashboard':
+        setCurrentTab('dashboards');
+        break;
+      case 'Alert':
+        setCurrentTab('alerts');
+        break;
+      case 'Doc':
+        setCurrentTab('data-sources');
+        break;
+      default:
+        setCurrentTab('overview');
+        break;
+    }
+  };
+
   return (
     <Surface key={key} base={Surface.BASE.PRIMARY}>
       <div
         css={css`
           padding: 1em;
+          cursor: pointer;
         `}
+        onClick={() => navigateToTab(tag)}
       >
         <h3>{title}</h3>
         <div>


### PR DESCRIPTION
- Now the tiles in the overview tab on category landing page are clickable
- on click the of the tile it will open respective tab