### PR TITLE
Example: make nr logo link open in same tab

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
@@ -8,6 +8,7 @@ import Button from '@newrelic/gatsby-theme-newrelic/src/components/Button';
 import Dropdown from '@newrelic/gatsby-theme-newrelic/src/components/Dropdown';
 import NewRelicLogo from '@newrelic/gatsby-theme-newrelic/src/components/NewRelicLogo';
 import GlobalNavLink from '@newrelic/gatsby-theme-newrelic/src/components/GlobalNavLink';
+import { useInstrumentedHandler } from '@newrelic/gatsby-theme-newrelic';
 import useMedia from 'use-media';
 import useThemeTranslation from '@newrelic/gatsby-theme-newrelic/src/hooks/useThemeTranslation';
 import { rgba } from 'polished';
@@ -169,8 +170,14 @@ const GlobalHeader = ({ className, activeSite }) => {
               }
             `}
           >
-            <ExternalLink
+            <a
               href="https://newrelic.com/"
+              onClick={useInstrumentedHandler(null, {
+                eventName: 'externalLinkClick',
+                category: 'LinkClick',
+                origin: 'globalHeader',
+                href: 'https://newrelic.com',
+              })}
               css={css`
                 display: flex;
                 align-items: center;
@@ -193,7 +200,7 @@ const GlobalHeader = ({ className, activeSite }) => {
                   }
                 `}
               />
-            </ExternalLink>
+            </a>
 
             <Dropdown
               css={css`


### PR DESCRIPTION
## Summary
Quick implementation for opening the top left brand logo link in the same tab, while keeping current instrumentation.