### PR TITLE
bug:cookie banner is not centered

### DIFF
--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -53,3 +53,13 @@ input[type='text'] {
 {
     height: inherit !important;
 } 
+@media only screen and (max-width: 425px){
+  #onetrust-banner-sdk.otFloatingRoundedCorner {
+    width: 100% !important;
+  }
+}
+@media only screen and (min-width: 426px) and (max-width: 896px) {
+  #onetrust-banner-sdk.otFloatingRoundedCorner {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
fixes #88 
JIRA:https://newrelic.atlassian.net/browse/CXPUI-40
Description: centered the cookie modal better on mobile views
**OLD VIEW:**
<img width="401" alt="Screenshot 2022-03-16 at 1 06 05 PM" src="https://user-images.githubusercontent.com/99384747/158539548-d33df842-3c54-4e9c-a686-e631f6eb76e0.png">
**NEW VIEW**
with different resolutions
<img width="413" alt="Screenshot 2022-03-16 at 12 51 09 PM" src="https://user-images.githubusercontent.com/99384747/158539663-e9f0dd65-c6d1-4224-9a15-4fb561c75fc7.png">

<img width="518" alt="Screenshot 2022-03-16 at 12 51 30 PM" src="https://user-images.githubusercontent.com/99384747/158539712-e2f6cc91-7eb1-487e-a022-69a179128028.png">
@mdumpati review the changes

