### PR TITLE
chore: fixes header image url  path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Community Project header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
+[![Community Project header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Community_Project.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#category-community-project)
+
 
 # Instant Observability Website
 


### PR DESCRIPTION
This PR should finally appease repo-linter, I checked what image was being used on the OSS site's [readme](https://github.com/newrelic/opensource-website/blob/develop/README.md) and pointed to this image file found on master. I think this will appease repo-linter as it still seems to looks for[ these master branch images](https://github.com/newrelic/.github/issues/31)