### PR TITLE
fix for broken 404 page

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^4.0.5",
+    "@newrelic/gatsby-theme-newrelic": "^5.0.4",
     "@splitsoftware/splitio-react": "^1.2.0",
     "gatsby": "^4.10.0",
     "gatsby-plugin-emotion": "^6.8.0",

--- a/src/components/IOSeo.js
+++ b/src/components/IOSeo.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { SEO as Seo } from '@newrelic/gatsby-theme-newrelic';
-import { useStaticQuery, graphql, withPrefix } from 'gatsby';
+import { useStaticQuery, graphql } from 'gatsby';
 
-function IOSeo({ description, meta, title, tags, location, type }) {
+function IOSeo ({ description, meta, title, tags, location, type }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -103,7 +103,6 @@ function IOSeo({ description, meta, title, tags, location, type }) {
       {validMetadata.map((data, index) => (
         <meta key={`${data.name}-${index}`} {...data} />
       ))}
-      <script src={withPrefix('tessen.min-1.3.0.js')} type="text/javascript" />
     </Seo>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,10 +1980,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^4.0.5":
-  version "4.1.8"
-  resolved "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-4.1.8.tgz"
-  integrity sha512-wXKxPVnZC/KocBc9l+FLmxCacqyz6QSMyX2c5Y/ZD66cM95Y32dtD6ktklTLWXvx1NK9ywrDdjCdvY1lGNcqyQ==
+"@newrelic/gatsby-theme-newrelic@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-5.0.4.tgz#fba9daed3c3f6ee9309f0a713a181b66757fe7a9"
+  integrity sha512-4mb2AnV/DCVcBrc4VdZeVwm4iX3WOGuwugbau8aDQRxFKMESIC1m1fis243EIB8+GXkIMns4NspDge9O3wDJ/A==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"
@@ -1994,11 +1994,11 @@
     gatsby-plugin-newrelic "^2.0.0"
     gatsby-plugin-react-helmet "^4.10.0"
     gatsby-plugin-robots-txt "^1.6.8"
-    gatsby-plugin-sharp "^3.10.2"
+    gatsby-plugin-sharp "^4.4.0"
     gatsby-plugin-sitemap "^4.6.0"
     gatsby-plugin-use-dark-mode "^1.3.0"
     gatsby-source-filesystem "^3.10.0"
-    gatsby-transformer-sharp "^3.10.0"
+    gatsby-transformer-sharp "^4.6.0"
     html-react-parser "^1.2.5"
     i18next "^20.2.1"
     js-cookie "^2.2.1"
@@ -3974,9 +3974,9 @@ async@1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^3.2.1:
+async@^3.2.1, async@^3.2.3:
   version "3.2.3"
-  resolved "https://registry.npmjs.org/async/-/async-3.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
@@ -5597,7 +5597,7 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4:
+debug@4, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -7221,6 +7221,27 @@ gatsby-core-utils@^3.11.0-next.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-3.11.1.tgz#ea87c1d3aa45c26c9ea32b8e8b029afe6a56f8c7"
+  integrity sha512-Op9/uihtcsDLlZDfRsGJ1ya2mFx2YH9Zmx93bawElZ0YpIzKjCkNTp+I5i5UANxvs5I+Fljl0WHQRudMWg+fWA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fastq "^1.13.0"
+    file-type "^16.5.3"
+    fs-extra "^10.0.0"
+    got "^11.8.3"
+    import-from "^4.0.0"
+    lmdb "^2.2.4"
+    lock "^1.1.0"
+    node-object-hash "^2.3.10"
+    proper-lockfile "^4.1.2"
+    resolve-from "^5.0.0"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-graphiql-explorer@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-2.10.0.tgz#6d36ed936170673b7439989c2617369a151c4e51"
@@ -7423,7 +7444,7 @@ gatsby-plugin-sass@^4.8.0:
     resolve-url-loader "^3.1.2"
     sass-loader "^10.1.1"
 
-gatsby-plugin-sharp@^3.10.2, gatsby-plugin-sharp@^3.14.1:
+gatsby-plugin-sharp@^3.14.1:
   version "3.14.3"
   resolved "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-3.14.3.tgz"
   integrity sha512-96H2HxJe4EHjnwp3Qn2LoKoPwciMf5TXwir9h9QR/+fTqld0OhU5Q4PjWciELmGXW7AzXKpSoTvRmA322kgPhg==
@@ -7444,6 +7465,31 @@ gatsby-plugin-sharp@^3.10.2, gatsby-plugin-sharp@^3.14.1:
     progress "^2.0.3"
     semver "^7.3.5"
     sharp "^0.29.0"
+    svgo "1.3.2"
+    uuid "3.4.0"
+
+gatsby-plugin-sharp@^4.4.0:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-4.11.1.tgz#c6459f6636696919b4688b471fe4d4f1cf6f1f9a"
+  integrity sha512-wmbDnVl1386Mpm446tCavrI818HBpFOYk53cTerj5vaS+YmmuALwKSYVYOT2+LuVvZW0oaijuaDBeDnftq882g==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    async "^3.2.3"
+    bluebird "^3.7.2"
+    debug "^4.3.3"
+    filenamify "^4.3.0"
+    fs-extra "^10.0.0"
+    gatsby-core-utils "^3.11.1"
+    gatsby-plugin-utils "^3.5.1"
+    gatsby-telemetry "^3.11.1"
+    got "^11.8.3"
+    lodash "^4.17.21"
+    mini-svg-data-uri "^1.4.3"
+    potrace "^2.1.8"
+    probe-image-size "^7.0.0"
+    progress "^2.0.3"
+    semver "^7.3.5"
+    sharp "^0.30.1"
     svgo "1.3.2"
     uuid "3.4.0"
 
@@ -7504,6 +7550,20 @@ gatsby-plugin-utils@^3.4.0:
     joi "^17.4.2"
     mime "^3.0.0"
 
+gatsby-plugin-utils@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-3.5.1.tgz#9aed9deec0f4ee82bfc7390f735b9455ca4f8494"
+  integrity sha512-RZXUvwQjTnkukMfAGr+DCz/qZj7g6REljTmQS43MaovWO4Yf4YGvs+1Leays7J0XmqN2I3SIZGBgt4tgKCsNVQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    fs-extra "^10.0.0"
+    gatsby-core-utils "^3.11.1"
+    gatsby-sharp "^0.5.0"
+    graphql-compose "^9.0.7"
+    import-from "^4.0.0"
+    joi "^17.4.2"
+    mime "^3.0.0"
+
 gatsby-react-router-scroll@^5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-5.10.0.tgz#4a146dbe4079024290b21599a67238189f73cd40"
@@ -7516,6 +7576,14 @@ gatsby-sharp@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/gatsby-sharp/-/gatsby-sharp-0.4.0.tgz#9e26c004935750bd334fb041da1b0ad5a5a6955c"
   integrity sha512-Q2iP6HEs1MRdcMRj7NwZ4l6/1U61vx2DrWNgGwqEEhIFAAgUMlWscaeCpEgahC3t4D66LmuDQkbzBvBcH0Dwxw==
+  dependencies:
+    "@types/sharp" "^0.29.5"
+    sharp "^0.30.1"
+
+gatsby-sharp@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/gatsby-sharp/-/gatsby-sharp-0.5.0.tgz#879d3c462eefa917cb3a50c6ec891951d9740f56"
+  integrity sha512-9wZS0ADZsKTCsU66sxIP/tCHgFaREyoYm53tepgtp/YSVWNrurx9/0kGf8XsFFY9OecrqIRNuk1cWe7XKCpbQA==
   dependencies:
     "@types/sharp" "^0.29.5"
     sharp "^0.30.1"
@@ -7597,6 +7665,25 @@ gatsby-telemetry@^3.11.0-next.0:
     lodash "^4.17.21"
     node-fetch "^2.6.7"
 
+gatsby-telemetry@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-3.11.1.tgz#87caed899143276056e9af20ab38c15ad9dcdf52"
+  integrity sha512-TPNKTpuYFyULOuRvhpXUtj8h2E7bvrTYsRC/aKeHoWqEchwwbzPwBSJd+3ZFjsxLHIXAa5sTAlR2wd9SYBgOlA==
+  dependencies:
+    "@babel/code-frame" "^7.14.0"
+    "@babel/runtime" "^7.15.4"
+    "@turist/fetch" "^7.1.7"
+    "@turist/time" "^0.0.2"
+    async-retry-ng "^2.0.1"
+    boxen "^4.2.0"
+    configstore "^5.0.1"
+    fs-extra "^10.0.0"
+    gatsby-core-utils "^3.11.1"
+    git-up "^4.0.5"
+    is-docker "^2.2.1"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+
 gatsby-transformer-json@^3.3.0:
   version "3.14.0"
   resolved "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-3.14.0.tgz"
@@ -7605,7 +7692,7 @@ gatsby-transformer-json@^3.3.0:
     "@babel/runtime" "^7.15.4"
     bluebird "^3.7.2"
 
-gatsby-transformer-sharp@^3.10.0, gatsby-transformer-sharp@^3.13.0:
+gatsby-transformer-sharp@^3.13.0:
   version "3.14.0"
   resolved "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-3.14.0.tgz"
   integrity sha512-p0bBu4Sheo4MrrrTRXEu+jcOvsvKmzr1Wc/CQ9VD1U7vTPj74a8JiMJ9GrXrkei5qcXXeXACjBTu5F0Hyg6qMQ==
@@ -7618,6 +7705,20 @@ gatsby-transformer-sharp@^3.10.0, gatsby-transformer-sharp@^3.13.0:
     probe-image-size "^6.0.0"
     semver "^7.3.5"
     sharp "^0.29.0"
+
+gatsby-transformer-sharp@^4.6.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-sharp/-/gatsby-transformer-sharp-4.11.0.tgz#e80bb5736cfe90e5ee7d826ee451a10f2d743c94"
+  integrity sha512-pQkQs7EALTWwuoEVOGxJt3/6CIF6AaNmp7tEqbqT3+iu6KiEAp5/YxRR56t8eQ6crVt1kajDSy1pQW8VRi5Sig==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    bluebird "^3.7.2"
+    common-tags "^1.8.2"
+    fs-extra "^10.0.0"
+    potrace "^2.1.8"
+    probe-image-size "^7.0.0"
+    semver "^7.3.5"
+    sharp "^0.30.1"
 
 gatsby-worker@^1.10.0:
   version "1.10.0"
@@ -10392,6 +10493,11 @@ mini-svg-data-uri@^1.3.3:
   resolved "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.3.tgz"
   integrity sha512-gSfqpMRC8IxghvMcxzzmMnWpXAChSA+vy4cia33RgerMS8Fex95akUyQZPbxJJmeBGiGmK7n/1OpUX8ksRjIdA==
 
+mini-svg-data-uri@^1.4.3:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
+  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
+
 minimatch@3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
@@ -11832,6 +11938,15 @@ probe-image-size@^6.0.0:
   integrity sha512-99PZ5+RU4gqiTfK5ZDMDkZtn6eL4WlKfFyVJV7lFQvH3iGmQ85DqMTOdxorERO26LHkevR2qsxnHp0x/2UDJPA==
   dependencies:
     deepmerge "^4.0.0"
+    needle "^2.5.2"
+    stream-parser "~0.3.1"
+
+probe-image-size@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-7.2.3.tgz#d49c64be540ec8edea538f6f585f65a9b3ab4309"
+  integrity sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==
+  dependencies:
+    lodash.merge "^4.6.2"
     needle "^2.5.2"
     stream-parser "~0.3.1"
 


### PR DESCRIPTION
## Summary
Changes were made to theme to resolve errors around using tessen when it wasn't loaded. Additionally, using Gatsby's path prefix with tessen was also fixed. So the 404 page should be fixed in the case where tessen isn't loaded, but should also be fixed to work now when it wasn't previously.

Finally, with these tessen changes, we can remove the hardcoded script block we had to get around this problem since tessen is now correctly sourced and should no longer break pages if not loaded.

## Links
Relates to: #99