### PR TITLE
feat: NR3156 - Heading tags updated

### DIFF
--- a/src/components/EmptyTab.js
+++ b/src/components/EmptyTab.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Button, Icon, Link } from '@newrelic/gatsby-theme-newrelic';
 import { QUICKSTARTS_REPO } from '../data/constants';
+import GitHubIconSVG from '../components/Icons/GitHubIconSVG';
 
 const EmptyTab = ({
   quickstartName,
@@ -39,20 +40,32 @@ const EmptyTab = ({
       `}
     >
       <Button
+        css={css`
+              background: var(--background-color);
+              color: var(--btn-text-color);
+              border-radius: 4px;
+              padding: 13.5px 20px 13.5px 22px;
+              column-gap: 14.45px; 
+              
+              &:hover{
+                color: var(--white-hover-color);
+                background-color: var(--background-color);
+                }
+
+                @media (max-width: 760px) {
+                    width: 100%;
+                }
+            `}
         as={Link}
         variant={Button.VARIANT.PRIMARY}
         to={quickstartUrl}
         rel="noopener noreferrer"
         instrumentation={{ quickstartName }}
       >
-        <Icon
-          name="fe-github"
-          css={css`
-            margin-right: 7px;
-          `}
-        />
+        <GitHubIconSVG className="ViewRepo" />
         View repo
       </Button>
+
     </div>
   </div>
 );

--- a/src/components/LandingPageFooter.js
+++ b/src/components/LandingPageFooter.js
@@ -79,6 +79,7 @@ const LandingPageFooter = ({
                                 border-radius: 4px;
                                 padding: 13.5px 20px 13.5px 22px;
                                 column-gap: 14.45px; 
+                                font-weight: 400; 
                                 &:hover{
                                     color: var(--white-hover-color);
                                   }
@@ -116,7 +117,8 @@ const LandingPageFooter = ({
                                 color: var(--btn-text-color);
                                 border-radius: 4px;
                                 padding: 13.5px 20px 13.5px 22px;
-                                column-gap: 14.45px;    
+                                column-gap: 14.45px;   
+                                font-weight: 400; 
                                 &:hover{
                                     color: var(--white-hover-color);
                                 }

--- a/src/components/LandingPageFooter.js
+++ b/src/components/LandingPageFooter.js
@@ -39,6 +39,8 @@ const LandingPageFooter = ({
                         margin-right: 155px;
                       h6 {
                           margin-bottom: 66px;
+                            font-weight: 400;
+                        
                       }
                       .collaborate-section {
                           margin-bottom: 34px !important;

--- a/src/components/LandingPageFooter.js
+++ b/src/components/LandingPageFooter.js
@@ -26,6 +26,7 @@ const LandingPageFooter = ({
                     grid-template-columns: repeat(4, 1fr);
                     gap: 10px;
                     grid-auto-rows: minmax(100px, auto);
+                    font-size: 18px;
 
                     @media (max-width: 760px) {
                         grid-template-columns: repeat(1, 1fr);
@@ -36,24 +37,27 @@ const LandingPageFooter = ({
                     @media (min-width: 760px) {
                       margin-left: 156px;
                         margin-right: 155px;
-                      h3 {
-                          margin-bottom: 58px
+                      h6 {
+                          margin-bottom: 66px;
+                      }
+                      .collaborate-section {
+                          margin-bottom: 34px !important;
                       }
                     }
           `}>
                 <PageTools.Section>
-                    <h3>
+                    <h6>
                         Authors
-                    </h3>
+                    </h6>
                     <p>
                         {quickstart.authors.join(', ')}
                     </p>
                 </PageTools.Section>
 
                 <PageTools.Section>
-                    <h3>
+                    <h6>
                         Support
-                    </h3>
+                    </h6>
                     <div>
                         <SupportSection
                             supportLevel={quickstart.level}
@@ -63,9 +67,9 @@ const LandingPageFooter = ({
                 </PageTools.Section>
 
                 <PageTools.Section>
-                    <h3>
+                    <h6 className='collaborate-section'>
                         Collaborate on this quickstart
-                    </h3>
+                    </h6>
                     <div>
                         <Button
                             css={css`
@@ -130,9 +134,9 @@ const LandingPageFooter = ({
                 </PageTools.Section>
 
                 <PageTools.Section>
-                    <h3>
+                    <h6>
                         Related Resources
-                    </h3>
+                    </h6>
                     <RelatedResources
                         css={css`
                             padding: 0;

--- a/src/components/LandingPageFooter.js
+++ b/src/components/LandingPageFooter.js
@@ -44,6 +44,13 @@ const LandingPageFooter = ({
                           margin-bottom: 34px !important;
                       }
                     }
+
+                    @media not all and (min-resolution:.001dpcm) and max-width: 760px { 
+                        @media {
+                            grid-template-columns: repeat(1, 1fr);
+                            margin-left: 40px;
+                          margin-right: 23px;
+                        }}
           `}>
                 <PageTools.Section>
                     <h6>

--- a/src/components/QuickstartAlerts.js
+++ b/src/components/QuickstartAlerts.js
@@ -53,13 +53,14 @@ const QuickstartAlerts = ({ quickstart }) => (
       
           `}
           />
-          <h3
+          <p
             css={css`
+            font-family: 'Söhne-Kräftig';
           margin-top: 16px;
           margin-bottom: 16px;
           `}>
             {alert.name}
-          </h3>
+          </p>
           {alert.details && <p>{alert.details}</p>}
         </Surface>
       ))}

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -65,34 +65,39 @@ const QuickstartDashboards = ({ quickstart }) => (
     {quickstart.dashboards.map((dashboard) => (
       <div key={dashboard.name}>
         <div>
-          <h3>{dashboard.name}</h3>
+          <p
+          css={css`
+          font-weight: 700 !important;
+          font-family: 'Söhne-Kräftig';
+
+          `}>
+            {dashboard.name}
+            </p>
           {dashboard.description && <p>{dashboard.description}</p>}
           <Slider {...settings}>
             {dashboard.screenshots.map((imgUrl) => {
               return (
                 <div>
-                  <h3>
-                    <animated.div
-                      css={css`
+                  <animated.div
+                    css={css`
                       display: flex;
                       height: 100%;
                       align-items: center;
                     `}
-                    >
-                      <a href={imgUrl} target="_blank" rel="noreferrer">
-                        <img
-                          src={imgUrl}
-                          css={css`
+                  >
+                    <a href={imgUrl} target="_blank" rel="noreferrer">
+                      <img
+                        src={imgUrl}
+                        css={css`
                             width: 100%;
                             max-height: 400px;
                             border-radius: 4px;
                             border: solid 1px var(--divider-color);
                             padding: 0.25rem;
                           `}
-                        />
-                      </a>
-                    </animated.div>
-                  </h3>
+                      />
+                    </a>
+                  </animated.div>
                 </div>
               );
             })}

--- a/src/components/QuickstartDataSources.js
+++ b/src/components/QuickstartDataSources.js
@@ -72,13 +72,14 @@ const QuickstartDataSources = ({ quickstart }) => {
              
            `}
             />
-            <h3
+            <p
               css={css`
+                font-family: 'Söhne-Kräftig';
                 margin-top: 16px;
                 margin-bottom: 16px;
                 `}>
               {doc.name}
-            </h3>
+            </p>
 
             {doc.description &&
               <p>

--- a/src/components/QuickstartHowToUse.js
+++ b/src/components/QuickstartHowToUse.js
@@ -26,11 +26,16 @@ const QuickstartHowToUse = ({
           }
 
           @media screen and (max-width: 760px){
-            display: grid;
-            grid-template-columns: repeat(1, 1fr);
             margin-left: 40px;
             margin-right: 23px;
         }
+
+        @media not all and (min-resolution:.001dpcm) and max-width: 760px { 
+          @media {
+              grid-template-columns: repeat(1, 1fr);
+              margin-left: 40px;
+            margin-right: 23px;
+          }}
         `}>
         <PageTools.Section>
           <h3
@@ -126,7 +131,7 @@ const QuickstartHowToUse = ({
             location={location}
             css={css`
                             background: var(--background-color);
-                            padding: 13px 20px 14px 20px;
+                            padding: 18px 20px 18px 20px;
                             font-weight: 400;
                           `} />
         </PageTools.Section>

--- a/src/components/QuickstartHowToUse.js
+++ b/src/components/QuickstartHowToUse.js
@@ -33,29 +33,35 @@ const QuickstartHowToUse = ({
         }
         `}>
         <PageTools.Section>
-          <div
+          <h3
             css={css`
             top: 0;
             padding-top: 0.5rem;
             height: 2.5rem;
             width: 100%;
+            font-weight: 400;
+
+            @media screen and (min-width: 760px){
+            line-height: 50px;
+            margin-bottom: 35px !important;
+            }
+
             @media screen and (max-width: 760px){
               padding-bottom: 58px !important;
+              margin-bottom: 24px !important;
+              line-height: 40px ;
             }
           `}
-          > 
-              <h1
-                css={css`
-                  `}>
-                How to use this quickstart
-              </h1>
-          </div>
+          >
+            How to use this quickstart
+          </h3>
         </PageTools.Section>
 
         <PageTools.Section>
           <ul
-          css={css`
+            css={css`
           color: var(--black-text-color);
+          font-size: 18px;
           `}>
             <li
               css={css`
@@ -121,6 +127,7 @@ const QuickstartHowToUse = ({
             css={css`
                             background: var(--background-color);
                             padding: 13px 20px 14px 20px;
+                            font-weight: 400;
                           `} />
         </PageTools.Section>
       </div>

--- a/src/components/QuickstartOverview.js
+++ b/src/components/QuickstartOverview.js
@@ -44,10 +44,12 @@ const QuickstartOverview = ({ quickstart }) => {
             skipHtml
             allowedElements={allowedElements}
             css={css`
+            @media screen and (max-width: 760px){
               width: fit-content;
-              margin: 40px;
-              @media screen and (min-width: 1440px) {
-                margin: 104px 156px;
+              margin: 40px 70px 40px 58px;
+            }
+              @media screen and (min-width: 760px) {
+                margin: 104px 155px 104px  168px;
               }
             `}
           >

--- a/src/components/WhatsIncluded/Alerts.js
+++ b/src/components/WhatsIncluded/Alerts.js
@@ -20,6 +20,13 @@ const Alerts = ({ quickstart }) => {
           margin-left: 40px;
           margin-right: 23px;
         }
+
+        @media not all and (min-resolution:.001dpcm) and max-width: 760px { 
+            @media {
+                grid-template-columns: repeat(1, 1fr);
+                margin-left: 40px;
+              margin-right: 23px;
+            }}
         `}
         >
             <PageTools.Section>

--- a/src/components/WhatsIncluded/Alerts.js
+++ b/src/components/WhatsIncluded/Alerts.js
@@ -27,6 +27,10 @@ const Alerts = ({ quickstart }) => {
                 margin-left: 40px;
               margin-right: 23px;
             }}
+
+            h6{
+                font-weight: 400;
+            }
         `}
         >
             <PageTools.Section>

--- a/src/components/WhatsIncluded/Alerts.js
+++ b/src/components/WhatsIncluded/Alerts.js
@@ -14,7 +14,6 @@ const Alerts = ({ quickstart }) => {
 
         @media (min-width: 760px) {
           margin-left: 156px;
-            // margin-right: 155px;
         }
 
         @media (max-width: 760px) {
@@ -24,18 +23,19 @@ const Alerts = ({ quickstart }) => {
         `}
         >
             <PageTools.Section>
-                <h2>
+                <h6>
                     Alerts &nbsp;
                     <div
                         css={css`
                         display: inline-block;
-                        background: #D6D6D6;
-                        padding: 4px 6px 4px 6px;
+                        background: var(--background-grey-color);
+                        margin: 0px 8px;
+                        padding: 1px 4px;
                         border-radius: 3px;
                     `}
                     >
                         {quickstart.alerts.length}</div>
-                </h2>
+                </h6>
                 {quickstart.alerts?.length > 0 ? (
                     <QuickstartAlerts quickstart={quickstart} />
                 ) : (

--- a/src/components/WhatsIncluded/Dashboards.js
+++ b/src/components/WhatsIncluded/Dashboards.js
@@ -23,6 +23,13 @@ const Dashboards = ({ quickstart }) => {
           margin-right: 23px;
           
         }
+
+        @media not all and (min-resolution:.001dpcm) and max-width: 760px { 
+            @media {
+                grid-template-columns: repeat(1, 1fr);
+                margin-left: 40px;
+              margin-right: 23px;
+            }}
         `}
         >
             <PageTools.Section>

--- a/src/components/WhatsIncluded/Dashboards.js
+++ b/src/components/WhatsIncluded/Dashboards.js
@@ -11,6 +11,11 @@ const Dashboards = ({ quickstart }) => {
             css={css`
         h3 {
             margin-bottom: 58px;
+            font-weight: 400;
+        }
+
+        h6 {
+            font-weight: 400;
         }
 
         @media (min-width: 760px) {

--- a/src/components/WhatsIncluded/Dashboards.js
+++ b/src/components/WhatsIncluded/Dashboards.js
@@ -9,7 +9,7 @@ const Dashboards = ({ quickstart }) => {
     return (
         <div
             css={css`
-        h1 {
+        h3 {
             margin-bottom: 58px;
         }
 
@@ -26,22 +26,23 @@ const Dashboards = ({ quickstart }) => {
         `}
         >
             <PageTools.Section>
-                <h1>
+                <h3>
                     What&apos;s included?
-                </h1>
-                <h2>
+                </h3>
+                <h6>
                     Dashboard
                     &nbsp;
                     <div
                         css={css`
                         display: inline-block;
-                        background: #D6D6D6;
-                        padding: 4px 6px 4px 6px;
+                        background: var(--background-grey-color);
+                        margin: 0px 8px;
+                        padding: 1px 4px;
                         border-radius: 3px;
                     `}
                     >
                         {quickstart.dashboards.length}</div>
-                </h2>
+                </h6>
                 {quickstart.dashboards?.length > 0 ? (
                     <QuickstartDashboards quickstart={quickstart} />
                 ) : (

--- a/src/components/WhatsIncluded/DataSources.js
+++ b/src/components/WhatsIncluded/DataSources.js
@@ -22,18 +22,19 @@ const DataSources = ({ quickstart }) => {
         `}
         >
             <PageTools.Section>
-                <h2>
+                <h6>
                     Data Sources &nbsp;
                     <div
                         css={css`
                         display: inline-block;
-                        background: #D6D6D6;
-                        padding: 4px 6px 4px 6px;
+                        background: var(--background-grey-color);
+                        margin: 0px 8px;
+                        padding: 1px 4px;
                         border-radius: 3px;
                     `}
                     >
                         {quickstart.documentation.length}</div>
-                </h2>
+                </h6>
                 {quickstart.documentation?.length > 0 ? (
                     <QuickstartDataSources quickstart={quickstart} />
                 ) : (

--- a/src/components/WhatsIncluded/DataSources.js
+++ b/src/components/WhatsIncluded/DataSources.js
@@ -26,6 +26,10 @@ const DataSources = ({ quickstart }) => {
                 margin-left: 40px;
               margin-right: 23px;
             }}
+
+            h6{
+                font-weight: 400;
+            }
         `}
         >
             <PageTools.Section>

--- a/src/components/WhatsIncluded/DataSources.js
+++ b/src/components/WhatsIncluded/DataSources.js
@@ -19,6 +19,13 @@ const DataSources = ({ quickstart }) => {
           margin-left: 40px;
           margin-right: 23px;
         }
+
+        @media not all and (min-resolution:.001dpcm) and max-width: 760px { 
+            @media {
+                grid-template-columns: repeat(1, 1fr);
+                margin-left: 40px;
+              margin-right: 23px;
+            }}
         `}
         >
             <PageTools.Section>

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -1,12 +1,13 @@
 :root {
   --height-mobile-nav-bar: 60px;
   --ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  --link-font-color: black;
+  --link-font-color: #1D252C;
   --hover-color: #1D252C;
   --white-hover-color: #F9FAFA;
   --background-color: #1D252C;
-  --btn-text-color: white;
+  --btn-text-color: #F9FAFA;;
   --black-text-color : #1D252C;
+  --background-grey-color : #D6D6D6;
 }
 h1,h2,h3{
   font-family: 'Söhne-Kräftig';
@@ -96,5 +97,5 @@ input[type='text'] {
 }
 
 .e132irl20 {
-  font-weight: none;
+  font-weight: 400;
 }

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -41,10 +41,6 @@ input[type='text'] {
   }
 }
 
-h3,h6 {
-  font-weight: 400;
-}
-
 :global {
   .intro-text {
     color: var(--secondary-text-color);

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -41,6 +41,10 @@ input[type='text'] {
   }
 }
 
+h3,h6 {
+  font-weight: 400;
+}
+
 :global {
   .intro-text {
     color: var(--secondary-text-color);

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -5,7 +5,7 @@
   --hover-color: #1D252C;
   --white-hover-color: #F9FAFA;
   --background-color: #1D252C;
-  --btn-text-color: #F9FAFA;;
+  --btn-text-color: #F9FAFA;
   --black-text-color : #1D252C;
   --background-grey-color : #D6D6D6;
 }
@@ -94,8 +94,4 @@ input[type='text'] {
   float: left;
   justify-content: center;
   align-items: center;
-}
-
-.e132irl20 {
-  font-weight: 400;
 }

--- a/src/layouts/QuickStartLayout.js
+++ b/src/layouts/QuickStartLayout.js
@@ -7,10 +7,9 @@ import {
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import '../components/styles.scss';
-import '../components/fonts.scss';
 import { QUICKSTARTS_COLLAPSE_BREAKPOINT } from '../data/constants';
-import '../components/fonts.scss';
 import Layout from '../components/Layout';
+import '../components/fonts.scss';
 
 const QuickStartLayout = ({ children }) => {
   return (


### PR DESCRIPTION
JIRA:https://issues.newrelic.com/browse/NR
Description: 1. header tags updated with few more css changes such as font-weight, button color updated for empty tag
2. Responsiveness fix for browsers

**
*******
**Firefox** screenshots
*******
**

![image](https://user-images.githubusercontent.com/101187392/166222196-d4287a55-8049-47b4-ba3c-d9278d747acd.png)

**
![image](https://user-images.githubusercontent.com/101187392/166222074-4d3f4cad-ca7f-4394-90d6-82ee6517cf43.png)


**
*******
**Chrome** screenshots
*******
**

![image](https://user-images.githubusercontent.com/101187392/166222349-39489049-4084-4a09-9784-4706c59bd9bb.png)

**
![image](https://user-images.githubusercontent.com/101187392/166222668-b6e284eb-8480-472b-90da-07daf501c174.png)

**
*******
Safari screenshots
*******
**
<img width="1680" alt="Screenshot 2022-05-02 at 3 36 20 PM" src="https://user-images.githubusercontent.com/101187392/166219339-50fdffaf-cd87-41cd-84b5-407ce49e23f6.png">
**
<img width="1680" alt="Screenshot 2022-05-02 at 3 36 45 PM" src="https://user-images.githubusercontent.com/101187392/166219359-5e9b2460-6ae9-4c39-91bb-a9036462c53d.png">
**
<img width="1680" alt="Screenshot 2022-05-02 at 3 37 01 PM" src="https://user-images.githubusercontent.com/101187392/166219362-4512db22-05a0-4652-80d6-2df727ca788e.png">
**
<img width="1680" alt="Screenshot 2022-05-02 at 3 37 15 PM" src="https://user-images.githubusercontent.com/101187392/166219447-673a03e0-40f0-485f-8d4b-bba6e42c8492.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 38 10 PM" src="https://user-images.githubusercontent.com/101187392/166219458-f6653e5d-c515-4047-a269-6556fc561036.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 38 21 PM" src="https://user-images.githubusercontent.com/101187392/166219461-96f77d82-fdb0-46ea-80bb-8e5f3d719265.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 38 36 PM" src="https://user-images.githubusercontent.com/101187392/166219462-73ce5db2-8a99-41a3-882e-3f9f88be0453.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 38 52 PM" src="https://user-images.githubusercontent.com/101187392/166219464-cef8f91f-798f-4c9c-8cbb-39ca78e7e098.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 38 59 PM" src="https://user-images.githubusercontent.com/101187392/166219466-89f6a17d-2253-453a-9a30-27fa85bf44ed.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 39 06 PM" src="https://user-images.githubusercontent.com/101187392/166219469-7b26fcfd-7211-4fe3-a3f9-5ca4707bb35d.png">
**
<img width="489" alt="Screenshot 2022-05-02 at 3 39 14 PM" src="https://user-images.githubusercontent.com/101187392/166219472-7fa976ac-35d0-46c4-bca8-aa50b0200e69.png">


<img width="489" alt="Screenshot 2022-05-02 at 3 39 20 PM" src="https://user-images.githubusercontent.com/101187392/166219490-00f6e931-494d-45aa-b79b-9c391ab46a21.png">



