### PR TITLE
feat: NR-1512 Quickstart Tiles UI Updates

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
@@ -94,14 +94,14 @@ const GlobalFooter = ({ className }) => {
             }}
           >
             <Icon
-              name="zap"
+              name="fe-zap"
               css={css`
                 margin-right: 7px;
               `}
             />
             Build your own
             <Icon
-              name="external-link"
+              name="fe-external-link"
               css={css`
                 margin-left: 7px;
               `}

--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -44,6 +44,18 @@ const featherIcons = {
       <polyline points="9 18 15 12 9 6" />
     </>
   ),
+  'arrow-left': (
+    <>
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </>
+  ),
+  'arrow-right': (
+    <>
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </>
+  ),
   circle: (
     <>
       <circle cx="12" cy="12" r="10" />

--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -68,7 +68,7 @@ const QuickstartTile = ({
         padding: 0 22px 35px 24px;
         overflow: hidden;
         height: 360px;
-        width: 250px;
+        min-width: 250px;
         margin: 0 auto;
         border: 1px solid #e4e5e6;
         border-radius: 8px;

--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -76,7 +76,7 @@ const QuickstartTile = ({
 
         @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
         padding: 0 32px 24px 32px;
-          width: 80%;
+          width: 100%;
           min-width: 250px;
         }
 

--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -8,17 +8,10 @@ import {
   Tag,
   Link,
 } from '@newrelic/gatsby-theme-newrelic';
-import {
-  SHIELD_LEVELS,
-  RESERVED_QUICKSTART_IDS,
-  LISTVIEW_BREAKPOINT,
-} from '../data/constants';
+import { SHIELD_LEVELS, RESERVED_QUICKSTART_IDS } from '../data/constants';
 import QuickstartImg from './QuickstartImg';
 
-const VIEWS = {
-  GRID: 'Grid view',
-  LIST: 'List view',
-};
+import './fonts.scss';
 
 const QuickstartTile = ({
   id,
@@ -63,8 +56,6 @@ const QuickstartTile = ({
     }
   };
 
-  const isListView = () => view === VIEWS.LIST;
-
   return (
     <Surface
       as={Link}
@@ -76,43 +67,34 @@ const QuickstartTile = ({
       css={css`
         --tile-image-height: 100px; /* Logo image height */
         --title-row-height: auto; /* Title height to allow space for longer string */
-        padding: 1rem;
+        padding: 0 22px 35px 24px;
         overflow: hidden;
+        height: 360px;
+        width: 250px;
+        margin: 0 auto;
+        border: 1px solid #e4e5e6;
+        border-radius: 8px;
+        box-shadow: none;
+
+        h4,
+        p,
+        span {
+          font-family: 'Söhne-Leicht';
+          letter-spacing: -0.5%;
+          color: #1d252c;
+          font-weight: 600;
+        }
 
         /* Default grid view */
         display: grid;
+        align-items: flex-start;
         grid-gap: 0.2rem;
-        grid-template-rows: var(--tile-image-height) var(--title-row-height) 1fr auto;
+        grid-template-rows: var(--tile-image-height) 152px auto;
         grid-template-columns: auto;
         grid-template-areas:
           'logo logo'
-          'title title'
-          'summary summary'
-          '. tag';
-
-        /* List view selected by control */
-        ${
-          isListView() &&
-          css`
-            grid-template-columns: 1fr 1fr 1fr;
-            grid-template-areas:
-              'logo title title'
-              'logo summary summary'
-              'logo tag tag';
-            grid-template-rows: auto;
-          `
-        }
-
-        /* Breakpoint triggers List view */
-        @media screen and (max-width: ${LISTVIEW_BREAKPOINT}){
-          grid-template-areas:
-            'logo title title'
-            'logo summary summary';
-            'logo summary summary';
-          grid-template-columns: 1fr 1fr 1fr;
-          grid-template-rows: 0.5fr 1fr;
-          padding: 0.2rem 0.5rem;
-        }
+          'text text'
+          'tag arrow';
       `}
       onClick={() => handlePackClick(id)}
     >
@@ -122,21 +104,8 @@ const QuickstartTile = ({
           display: flex;
           grid-area: logo;
           height: 100%;
-          justify-content: center;
+          justify-content: flex-start;
           margin-bottom: 1rem;
-
-          .dark-mode & {
-            background: var(--color-white);
-          }
-
-          ${isListView() &&
-          css`
-            margin-right: 0.5rem;
-          `}
-
-          @media screen and (max-width: ${LISTVIEW_BREAKPOINT}) {
-            margin-right: 0.5rem;
-          }
         `}
       >
         <div
@@ -149,71 +118,90 @@ const QuickstartTile = ({
             packName={title || name}
             css={css`
               object-fit: scale-down;
-              height: 100%;
+              height: 45px;
+              margin: 35px 0 0;
             `}
           />
         </div>
       </div>
-      <h4
-        css={css`
-          grid-area: title;
-
-          @media screen and (max-width: ${LISTVIEW_BREAKPOINT}) {
-            align-self: end;
-            font-size: 14px;
-            font-weight: 300;
-            margin: 0;
-          }
-        `}
-      >
-        {title}{' '}
-        {SHIELD_LEVELS.includes(level) && <Icon name="nr-check-shield" />}
-      </h4>
 
       <div
         css={css`
-          grid-area: summary;
+          grid-area: text;
         `}
       >
-        <p
+        <h4
           css={css`
-            font-size: 0.8rem;
-            color: var(--secondary-text-color);
-
-            /* Limits the number of lines */
-            overflow: hidden;
-            display: -webkit-box;
-            text-overflow: ellipsis;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 3;
+            grid-area: title;
+            font-size: 24px;
+            letter-spacing: -0.5%;
           `}
         >
-          {summary || 'No summary provided'}
-        </p>
+          {title}{' '}
+          {SHIELD_LEVELS.includes(level) && <Icon name="nr-check-shield" />}
+        </h4>
+
+        <div
+          css={css`
+            grid-area: summary;
+            align-self: flex-start;
+          `}
+        >
+          <p
+            css={css`
+              font-size: 18px;
+              line-height: 24px;
+
+              /* Limits the number of lines */
+              overflow: hidden;
+              display: -webkit-box;
+              text-overflow: ellipsis;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 3;
+            `}
+          >
+            {summary || 'No summary provided'}
+          </p>
+        </div>
+      </div>
+
+      <div
+        css={css`
+          justify-self: start;
+          align-self: end;
+          grid-area: tag;
+        `}
+      >
+        <Tag
+          css={css`
+            background: #e4e5e6;
+            border-radius: 4px;
+            font-weight: 600;
+            height: 32px;
+            width: 100px;
+            padding: 3px 8px 5px;
+            color: red;
+            line-spacing: unset;
+          `}
+        >
+          Read more
+        </Tag>
       </div>
       <div
         css={css`
+          grid-area: arrow;
           justify-self: end;
           align-self: end;
-          span {
-            color: var(--color-brand-500);
-          }
-          grid-area: tag;
-
-          @media screen and (max-width: ${LISTVIEW_BREAKPOINT}) {
-            display: none;
-          }
         `}
       >
-        {featured && (
-          <Tag
-            css={css`
-              background-color: var(--color-brand-100);
-            `}
-          >
-            Featured
-          </Tag>
-        )}
+        <Icon
+          css={css`
+            height: 16px;
+            color: #1d252c;
+          `}
+          name="fe-arrow-right"
+          size="120%"
+        />
       </div>
     </Surface>
   );
@@ -221,7 +209,6 @@ const QuickstartTile = ({
 
 QuickstartTile.propTypes = {
   id: PropTypes.string.isRequired,
-  view: PropTypes.oneOf(Object.values(VIEWS)).isRequired,
   name: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   fields: PropTypes.shape({

--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -11,12 +11,13 @@ import {
 import { SHIELD_LEVELS, RESERVED_QUICKSTART_IDS } from '../data/constants';
 import QuickstartImg from './QuickstartImg';
 
+import { QUICKSTARTS_COLLAPSE_BREAKPOINT } from '../data/constants';
+
 import './fonts.scss';
 
 const QuickstartTile = ({
   id,
   title,
-  view,
   featured,
   name,
   fields,
@@ -34,7 +35,6 @@ const QuickstartTile = ({
         tessen.track({
           eventName: 'instantObservability',
           category: 'GuidedInstallClick',
-          publicCatalogView: view,
           quickstartName: name,
         });
         break;
@@ -42,7 +42,6 @@ const QuickstartTile = ({
         tessen.track({
           eventName: 'instantObservability',
           category: 'BuildYourOwnQuickstartClick',
-          publicCatalogView: view,
           quickstartName: name,
         });
         break;
@@ -50,7 +49,6 @@ const QuickstartTile = ({
         tessen.track({
           eventName: 'instantObservability',
           category: 'QuickstartClick',
-          publicCatalogView: view,
           quickstartName: name,
         });
     }
@@ -76,6 +74,12 @@ const QuickstartTile = ({
         border-radius: 8px;
         box-shadow: none;
 
+        @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+        padding: 0 32px 24px 32px;
+          width: 80%;
+          min-width: 250px;
+        }
+
         h4,
         p,
         span {
@@ -83,9 +87,15 @@ const QuickstartTile = ({
           letter-spacing: -0.5%;
           color: #1d252c;
           font-weight: 600;
+
+          @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+          width: 100%;
+          font-family: 'Söhne-Buch';
+          font-weight: 400;
         }
 
-        /* Default grid view */
+        }
+
         display: grid;
         align-items: flex-start;
         grid-gap: 0.2rem;
@@ -95,6 +105,11 @@ const QuickstartTile = ({
           'logo logo'
           'text text'
           'tag arrow';
+
+          @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+        grid-template-rows: 125px; 152px auto;
+        }
+
       `}
       onClick={() => handlePackClick(id)}
     >
@@ -120,6 +135,12 @@ const QuickstartTile = ({
               object-fit: scale-down;
               height: 45px;
               margin: 35px 0 0;
+
+              @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+                margin: 20px 0 0;
+                height: 70px;
+                max-width: 240px;
+              }
             `}
           />
         </div>
@@ -158,6 +179,10 @@ const QuickstartTile = ({
               text-overflow: ellipsis;
               -webkit-box-orient: vertical;
               -webkit-line-clamp: 3;
+
+              @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+                -webkit-line-clamp: 2;
+              }
             `}
           >
             {summary || 'No summary provided'}

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -39,4 +39,3 @@ export const RESERVED_QUICKSTART_IDS = {
 };
 
 export const QUICKSTARTS_COLLAPSE_BREAKPOINT = '760px';
-export const LISTVIEW_BREAKPOINT = '1080px';

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -26,8 +26,8 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../components/fonts.scss';
 
-const DOUBLE_COLUMN_BREAKPOINT = '1160px';
 const TRIPLE_COLUMN_BREAKPOINT = '1420px';
+const DOUBLE_COLUMN_BREAKPOINT = '1180px';
 const SINGLE_COLUMN_BREAKPOINT = '900px';
 
 /**

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -300,9 +300,9 @@ const QuickstartsPage = ({ data, location }) => {
               overflow: auto;
 
               label {
-                font-family: 'Söhne-Buch';
+                font-family: 'Söhne-Leicht';
                 font-size: 28px;
-                font-weight: 400;
+                font-weight: 600;
                 line-height: 36px;
                 margin-bottom: 12px;
                 letter-spacing: -0.5px;
@@ -322,9 +322,9 @@ const QuickstartsPage = ({ data, location }) => {
                   onClick={() => handleCategory(value)}
                   css={css`
                     padding: 8px 12px;
-                    font-family: 'Söhne-Buch';
+                    font-family: 'Söhne-Leicht';
                     font-size: 18px;
-                    font-weight: 400;
+                    font-weight: 600;
                     line-height: 54px;
                     width: 100%;
                     display: flex;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -16,10 +16,7 @@ import { navigate } from '@reach/router';
 
 import { useDebounce } from 'react-use';
 import { sortFeaturedQuickstarts } from '../utils/sortFeaturedQuickstarts';
-import {
-  QUICKSTARTS_COLLAPSE_BREAKPOINT,
-  LISTVIEW_BREAKPOINT,
-} from '../data/constants';
+import { QUICKSTARTS_COLLAPSE_BREAKPOINT } from '../data/constants';
 import CATEGORIES from '../data/instant-observability-categories';
 
 import SuperTiles from '../components/SuperTiles';
@@ -28,11 +25,6 @@ import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../components/fonts.scss';
-
-const VIEWS = {
-  GRID: 'Grid view',
-  LIST: 'List view',
-};
 
 const DOUBLE_COLUMN_BREAKPOINT = '1180px';
 const TRIPLE_COLUMN_BREAKPOINT = '1350px';
@@ -86,7 +78,6 @@ const filterByCategory = (category) => {
 };
 
 const QuickstartsPage = ({ data, location }) => {
-  const [view] = useState(VIEWS.GRID);
   const tessen = useTessen();
 
   const [search, setSearch] = useState('');
@@ -272,9 +263,11 @@ const QuickstartsPage = ({ data, location }) => {
           grid-gap: 70px;
           min-height: calc(100vh - var(--global-header-height));
           margin: var(--banner-height) auto;
+
           max-width: var(--site-max-width);
 
           @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+            margin: 500px auto;
             grid-gap: 0;
             grid-template-columns: minmax(0, 1fr);
             grid-template-areas: 'main';
@@ -528,24 +521,16 @@ const QuickstartsPage = ({ data, location }) => {
                       padding: 10px;
                       grid-template-columns: repeat(4, 1fr);
                       grid-auto-rows: 1fr;
-                      ${view === VIEWS.GRID &&
-                      css`
-                        @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
-                          grid-template-columns: repeat(3, 1fr);
-                        }
-                        @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
-                          grid-template-columns: repeat(2, 1fr);
-                        }
-                        @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
-                          grid-template-columns: repeat(1, 1fr);
-                        }
-                      `}
-                      ${view === VIEWS.LIST &&
-                      css`
-                        grid-auto-rows: 1fr;
-                        grid-template-columns: 1fr;
-                        grid-gap: 1.25rem;
-                      `};
+
+                      @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
+                        grid-template-columns: repeat(3, 1fr);
+                      }
+                      @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
+                        grid-template-columns: repeat(2, 1fr);
+                      }
+                      @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
+                        grid-template-columns: repeat(1, 1fr);
+                      }
                     `}
                   >
                     {!loadComplete && <Spinner />}
@@ -560,7 +545,6 @@ const QuickstartsPage = ({ data, location }) => {
                         {mostPopularQuickStarts.map((pack) => (
                           <QuickstartTile
                             key={pack.id}
-                            view={view}
                             featured={false}
                             css={css`
                               grid-template-rows:
@@ -608,24 +592,16 @@ const QuickstartsPage = ({ data, location }) => {
                   grid-gap: 1.25rem;
                   grid-template-columns: repeat(4, 1fr);
                   grid-auto-rows: 1fr;
-                  ${view === VIEWS.GRID &&
-                  css`
-                    @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
-                      grid-template-columns: repeat(3, 1fr);
-                    }
-                    @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
-                      grid-template-columns: repeat(2, 1fr);
-                    }
-                    @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
-                      grid-template-columns: repeat(1, 1fr);
-                    }
-                  `}
-                  ${view === VIEWS.LIST &&
-                  css`
-                    grid-auto-rows: 1fr;
-                    grid-template-columns: 1fr;
-                    grid-gap: 1.25rem;
-                  `};
+
+                  @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
+                    grid-template-columns: repeat(3, 1fr);
+                  }
+                  @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
+                    grid-template-columns: repeat(2, 1fr);
+                  }
+                  @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
+                    grid-template-columns: repeat(1, 1fr);
+                  }
                 `}
               >
                 {!loadComplete && <Spinner />}
@@ -634,7 +610,6 @@ const QuickstartsPage = ({ data, location }) => {
                     {featuredQuickStarts.map((pack) => (
                       <QuickstartTile
                         key={pack.id}
-                        view={view}
                         featured={false}
                         css={css`
                           grid-template-rows:
@@ -704,36 +679,22 @@ const QuickstartsPage = ({ data, location }) => {
               grid-gap: 1.25rem;
               grid-template-columns: repeat(4, 1fr);
               grid-auto-rows: 1fr;
-              ${view === VIEWS.GRID &&
-              css`
-                @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
-                  grid-template-columns: repeat(3, 1fr);
-                }
+              @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {
+                grid-template-columns: repeat(3, 1fr);
+              }
 
-                @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
-                  grid-template-columns: repeat(2, 1fr);
-                }
+              @media (max-width: ${DOUBLE_COLUMN_BREAKPOINT}) {
+                grid-template-columns: repeat(2, 1fr);
+              }
 
-                @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
-                  grid-template-columns: repeat(1, 1fr);
-                }
-              `}
-              ${view === VIEWS.LIST &&
-              css`
-                grid-auto-rows: 1fr;
-                grid-template-columns: 1fr;
-                grid-gap: 1.25rem;
-              `};
+              @media (max-width: ${SINGLE_COLUMN_BREAKPOINT}) {
+                grid-template-columns: repeat(1, 1fr);
+              }
             `}
           >
             {!isSearchInputEmpty && <SuperTiles />}
             {filteredQuickstarts.map((pack) => (
-              <QuickstartTile
-                key={pack.id}
-                view={view}
-                featured={false}
-                {...pack}
-              />
+              <QuickstartTile key={pack.id} featured={false} {...pack} />
             ))}
           </div>
         </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -36,7 +36,7 @@ const VIEWS = {
 
 const DOUBLE_COLUMN_BREAKPOINT = '1180px';
 const TRIPLE_COLUMN_BREAKPOINT = '1350px';
-const SINGLE_COLUMN_BREAKPOINT = LISTVIEW_BREAKPOINT;
+const SINGLE_COLUMN_BREAKPOINT = QUICKSTARTS_COLLAPSE_BREAKPOINT;
 
 /**
  * Determines if one string is a substring of the other, case insensitive
@@ -393,7 +393,7 @@ const QuickstartsPage = ({ data, location }) => {
                   transform: rotate(-90deg);
                   margin: -4px;
                 `}
-                name="chevron-left"
+                name="fe-chevron-left"
                 size="120%"
               />
             </Button>
@@ -655,7 +655,7 @@ const QuickstartsPage = ({ data, location }) => {
               --text-color: var(--primary-text-color);
 
               padding: 1.25rem 0;
-              font-size: 16px;
+              font-size: 18px;
               color: var(--color-neutrals-800);
               display: flex;
               justify-content: space-between;
@@ -668,6 +668,9 @@ const QuickstartsPage = ({ data, location }) => {
                 /* target inner children of parent span */
                 span,
                 strong {
+                  font-family: 'Söhne-Leicht';
+
+                  letter-space: -0.5px;
                   @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
                     display: none;
                   }
@@ -680,6 +683,8 @@ const QuickstartsPage = ({ data, location }) => {
                 text-overflow: ellipsis;
                 overflow-x: hidden;
                 whitespace: nowrap;
+                font-weight: 100;
+                font-size: 28px;
               }
 
               @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -26,9 +26,9 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../components/fonts.scss';
 
-const DOUBLE_COLUMN_BREAKPOINT = '1180px';
-const TRIPLE_COLUMN_BREAKPOINT = '1350px';
-const SINGLE_COLUMN_BREAKPOINT = QUICKSTARTS_COLLAPSE_BREAKPOINT;
+const DOUBLE_COLUMN_BREAKPOINT = '1160px';
+const TRIPLE_COLUMN_BREAKPOINT = '1420px';
+const SINGLE_COLUMN_BREAKPOINT = '900px';
 
 /**
  * Determines if one string is a substring of the other, case insensitive
@@ -260,18 +260,20 @@ const QuickstartsPage = ({ data, location }) => {
           grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
           grid-template-areas: 'sidebar main';
           grid-template-rows: 1fr auto;
-          grid-gap: 70px;
+          grid-gap: 20px;
           min-height: calc(100vh - var(--global-header-height));
           margin: var(--banner-height) auto;
 
           max-width: var(--site-max-width);
 
           @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-            margin: 500px auto;
             grid-gap: 0;
             grid-template-columns: minmax(0, 1fr);
             grid-template-areas: 'main';
             grid-template-rows: unset;
+          }
+          @media screen and (max-width: 760px) {
+            margin: 500px auto;
           }
         `}
       >
@@ -676,7 +678,7 @@ const QuickstartsPage = ({ data, location }) => {
           <div
             css={css`
               display: grid;
-              grid-gap: 1.25rem;
+              grid-gap: 40px 15px;
               grid-template-columns: repeat(4, 1fr);
               grid-auto-rows: 1fr;
               @media (max-width: ${TRIPLE_COLUMN_BREAKPOINT}) {


### PR DESCRIPTION
- Update styles for quickstart tiles
- remove dark mode code in these components
- remove List vs Grid View code on homepage
- Update feather icon names - there were 3k warnings in the console because of this. There are a few that are coming from the `gatsby-theme`

This does not touch the Featured/Popular sections. They are build off of this component, but there are still a few adjustments that they require, and are handled in other tickets. 

Relates to [NR-1512](https://issues.newrelic.com/browse/NR-1512)

<img width="1432" alt="Screen Shot 2022-04-29 at 4 31 03 PM" src="https://user-images.githubusercontent.com/47728020/166080701-1f3537ec-e4b2-4b2b-ad4e-025a25b447a8.png">

<img width="428" alt="Screen Shot 2022-04-29 at 4 32 03 PM" src="https://user-images.githubusercontent.com/47728020/166080697-85b06d6b-a5e7-4588-876f-17394717be6b.png">

