### PR TITLE
Improve mobile styles of Read more tag

### DIFF
--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -171,10 +171,6 @@ const QuickstartTile = ({
               text-overflow: ellipsis;
               -webkit-box-orient: vertical;
               -webkit-line-clamp: 3;
-
-              @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-                -webkit-line-clamp: 2;
-              }
             `}
           >
             {summary || 'No summary provided'}
@@ -199,6 +195,10 @@ const QuickstartTile = ({
             padding: 3px 8px 5px;
             color: red;
             line-spacing: unset;
+            @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+              padding: 5px 12px 8px;
+              font-size: 14px;
+            }
           `}
         >
           Read more
@@ -209,12 +209,19 @@ const QuickstartTile = ({
           grid-area: arrow;
           justify-self: end;
           align-self: end;
+          @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+            height: 35px;
+          }
         `}
       >
         <Icon
           css={css`
             height: 16px;
             color: #1d252c;
+            @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
+              margin-top: 12px;
+              height: 24px;
+            }
           `}
           name="fe-arrow-right"
           size="120%"


### PR DESCRIPTION
increase the size of the `Read more` tag and arrow SVG on mobile view of Quickstart Tile
<img width="409" alt="Screen Shot 2022-05-09 at 11 29 39 AM" src="https://user-images.githubusercontent.com/47728020/167474658-a7fc7460-bad2-4a99-a834-10164472bd7f.png">
s