### PR TITLE
NR-5641: Search input text no longer overlaps with x icon

### DIFF
--- a/src/components/IOBanner.js
+++ b/src/components/IOBanner.js
@@ -97,7 +97,7 @@ const BannerHeaderContent = ({ search, setSearch, setIsSearchInputEmpty }) => {
             input {
               height: 64px;
               font-size: 18px;
-              padding: 20px 24px;
+              padding: 20px 55px 20px 24px;
               background: #1d252c;
               border: 1px solid #f9fafa;
               border-radius: 4px;


### PR DESCRIPTION
add padding to `input` element so text cannot overlap with `x` icon


<img width="755" alt="Screen Shot 2022-05-09 at 12 09 05 PM" src="https://user-images.githubusercontent.com/47728020/167480550-87bf2946-7a48-414d-bcb1-da7ad810becb.png">
 