### PR TITLE
carousel images dimension fix

### DIFF
--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -77,7 +77,11 @@ const QuickstartDashboards = ({ quickstart }) => (
           <Slider {...settings}>
             {dashboard.screenshots.map((imgUrl) => {
               return (
-                <div>
+                <div
+                  css={css`
+                    border: solid 1px var(--border-color);
+                  `}
+                >
                   <animated.div
                     css={css`
                       display: flex;
@@ -85,16 +89,22 @@ const QuickstartDashboards = ({ quickstart }) => (
                       align-items: center;
                     `}
                   >
-                    <a href={imgUrl} target="_blank" rel="noreferrer">
+                    <a
+                      href={imgUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      css={css`
+                        margin: auto;
+                      `}
+                    >
                       <img
                         src={imgUrl}
                         css={css`
-                            width: 100%;
-                            max-height: 400px;
-                            border-radius: 4px;
-                            border: solid 1px var(--divider-color);
-                            padding: 0.25rem;
-                          `}
+                          width: 100%;
+                          height: 250px;
+                          border-radius: 4px;
+                          padding: 0.25rem;
+                        `}
                       />
                     </a>
                   </animated.div>


### PR DESCRIPTION
JIRA:https://issues.newrelic.com/browse/NR-6353
Description:Fix in Carousel images in the landing pages are of different dimensions.
Below are the Screenshots :
For web view:
<img width="1223" alt="Screenshot 2022-05-10 at 1 11 55 PM" src="https://user-images.githubusercontent.com/99384747/167575997-7ee4eb74-3207-40a3-941e-77d7b26b956a.png">
For mobile view:
<img width="403" alt="Screenshot 2022-05-10 at 1 11 38 PM" src="https://user-images.githubusercontent.com/99384747/167576020-0f1cdda5-1368-4b47-9189-85c7d34eafe1.png">

