### PR TITLE
NR-6457: Missing dashboard descriptions

### DIFF
--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -45,13 +45,35 @@ const settings = {
   ],
 };
 
+const renderDescription = (dashboard) => {
+  let descriptionToShow = '';
+  // check if description field is present
+  if (dashboard.description) {
+    // check if description and name are same
+    if (dashboard.description === dashboard.name) {
+      // if both are same, then descriptionToShow will be empty
+      descriptionToShow = '';
+    } else {
+      // if both are not same, then descriptionToShow will be the received description
+      descriptionToShow = dashboard.description
+    }
+  } else {
+    // if description field is not present then the descriptionToShow will be empty
+    descriptionToShow = '';
+  }
+  // render description
+  return (
+    <p>{descriptionToShow}</p>
+  )
+}
+
 const QuickstartDashboards = ({ quickstart }) => (
   <>
     <Intro
       css={css`
         margin-bottom: 16px;
         color: var(--black-text-color);
-        @media screen and (max-width: 760px){
+        @media screen and (max-width: 760px) {
           display: none;
         }
       `}
@@ -66,14 +88,14 @@ const QuickstartDashboards = ({ quickstart }) => (
       <div key={dashboard.name}>
         <div>
           <p
-          css={css`
-          font-weight: 700 !important;
-          font-family: 'Söhne-Kräftig';
-
-          `}>
+            css={css`
+              font-weight: 700 !important;
+              font-family: 'Söhne-Kräftig';
+            `}
+          >
             {dashboard.name}
-            </p>
-          {dashboard.description && <p>{dashboard.description}</p>}
+          </p>
+          {renderDescription(dashboard)}
           <Slider {...settings}>
             {dashboard.screenshots.map((imgUrl) => {
               return (
@@ -111,7 +133,8 @@ const QuickstartDashboards = ({ quickstart }) => (
                 </div>
               );
             })}
-          </Slider></div>
+          </Slider>
+        </div>
       </div>
     ))}
   </>


### PR DESCRIPTION
**JIRA ticket**: NR-6457
**Description**:
Show empty description if the dashboards don't have a valid description

**Previous**:
<img width="1439" alt="Screenshot 2022-05-11 at 2 22 31 PM" src="https://user-images.githubusercontent.com/99316285/167810615-d4d24b84-b8ba-425c-aaa3-c5ceddd82fc0.png">

**Now**
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/99316285/167810793-1f6dae55-f15d-4b87-beb4-c8f68afab093.png">

