### PR TITLE
fix/space-on-showing-results-heading

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -612,7 +612,7 @@ const QuickstartsPage = ({ data, location }) => {
               --text-color: var(--primary-text-color);
               margin: 0px 0 13px 4px;
 
-              padding: 1.25rem 0;
+              padding: 0 0 1.25rem 0;
               font-size: 18px;
               color: var(--color-neutrals-800);
               display: flex;


### PR DESCRIPTION
JIRA ticket: https://issues.newrelic.com/browse/NR-11129

Description: observed space above the title on clicking on a category on the left panel

Previous:
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/99316285/168846972-e4e5867f-c4fe-495f-98a0-4a9762b73528.png">


Now
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/99316285/168847023-798ab8a4-b174-4e2c-948b-b38f0555a1e0.png">
:
