### PR TITLE
NR-10872-  Gap between header banner & Most Popular / Categories need…

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -29,6 +29,7 @@ import RightArrowSVG from '../components/Icons/RightArrowSVG';
 const TRIPLE_COLUMN_BREAKPOINT = '1420px';
 const DOUBLE_COLUMN_BREAKPOINT = '1180px';
 const SINGLE_COLUMN_BREAKPOINT = '900px';
+const COLUMN_BREAKPOINT = '1131px';
 
 /**
  * Determines if one string is a substring of the other, case insensitive
@@ -289,6 +290,10 @@ const QuickstartsPage = ({ data, location }) => {
           padding: var(--banner-height) 0 15vh 0;
 
           max-width: var(--site-max-width);
+
+          @media screen and (min-width: ${COLUMN_BREAKPOINT}) {
+          --banner-height: 394px;
+          }
 
           @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
             grid-gap: 0;


### PR DESCRIPTION
JIRA : https://issues.newrelic.com/browse/NR-10872
Description: 
Added a constant variable having '1131px'. Using this breakpoint for maintaining gap of 50px between **banner** and **Most popular/categories**.

Before change
*******
![image](https://user-images.githubusercontent.com/101187392/169004914-cf903192-69ac-4c22-8f46-7b9b2a3b68a1.png)

After change
*******
![image](https://user-images.githubusercontent.com/101187392/169005050-ea19c9ef-74d5-440b-aa5d-6e6f6cbe9156.png)
