### PR TITLE
NR-10893 fix social icons alignment as home page

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
@@ -34,6 +34,34 @@ const GlobalFooter = ({ className }) => {
     }
   `);
 
+  // these icons will be hidden on mobile view
+  const renderSocialIcons = () => {
+    return (
+      SOCIALS.map((social) => (
+        <ExternalLink
+          key={social.title}
+          href={social.href}
+          css={css`
+            @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+              display: none;
+            }
+          `}
+        >
+          <Icon
+            name={social.title}
+            size="24px"
+            css={css`
+              outline: none;
+              stroke-width: 0px;
+              color: var(--secondary-text-color);
+              fill: var(--secondary-text-color);
+            `}
+          />
+        </ExternalLink>
+      ))
+    )
+  }
+
   return (
     <footer
       data-swiftype-index={false}
@@ -172,7 +200,7 @@ const GlobalFooter = ({ className }) => {
 
                 > span {
                   grid-column: span 7;
-                  margin-bottom: 14px;
+                  margin-bottom: 2rem;
                 }
 
                 > a {
@@ -183,20 +211,41 @@ const GlobalFooter = ({ className }) => {
           >
             <span>Follow us</span>
 
-            {SOCIALS.map((social) => (
-              <ExternalLink key={social.title} href={social.href}>
-                <Icon
-                  name={social.title}
-                  size="24px"
-                  css={css`
-                    outline: none;
-                    stroke-width: 0px;
-                    color: var(--secondary-text-color);
-                    fill: var(--secondary-text-color);
-                  `}
-                />
-              </ExternalLink>
-            ))}
+            {/* hide icons on mobile view and display them on large screens */}
+            {renderSocialIcons()}
+
+            {/* display icons on mobile view and hide on large screens */}
+            <div
+              css={css`
+                display: none;
+                @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+                  padding: 0;
+                  row-gap: 2rem;
+                  column-gap: 1.5rem;
+                  flex-wrap: wrap;
+                  flex-direction: row;
+                  max-width: 10.5rem;
+                  display: flex;
+                  margin-bottom: 1rem;
+                  justify-content: flex-start;
+                }
+              `}
+            >
+              {SOCIALS.map((social) => (
+                <ExternalLink key={social.title} href={social.href}>
+                  <Icon
+                    name={social.title}
+                    size="24px"
+                    css={css`
+                      outline: none;
+                      stroke-width: 0px;
+                      color: var(--secondary-text-color);
+                      fill: var(--secondary-text-color);
+                    `}
+                  />
+                </ExternalLink>
+              ))}
+            </div>
           </div>
           <div
             css={css`
@@ -290,11 +339,12 @@ const GlobalFooter = ({ className }) => {
           </div>
           <div
             css={css`
-              margin: 32px 0px 20px 0px;
+              margin-top: 1.25rem;
               font-size: 0.875rem;
               line-height: 1.25rem;
               @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                margin: 32px 0px 20px 40px;
+                margin-top: 2rem;
+                margin-left: 40px;
               }
             `}
           >

--- a/src/layouts/QuickStartLayout.js
+++ b/src/layouts/QuickStartLayout.js
@@ -46,7 +46,7 @@ const QuickStartLayout = ({ children }) => {
           }
 
           @media screen and (max-width: 920px) {
-            --footer-height: 1240px;
+            --footer-height: 72rem;
           }
         `}
       />


### PR DESCRIPTION
JIRA ticket: https://issues.newrelic.com/browse/NR-10893
Description: Social media icons should be in 2 rows like in HP. Needs to be in sync with NR Homepage.

Previous:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/99316285/169107179-653c8be8-5977-47fa-a105-4747a2bd601c.png">


Now:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/99316285/169107232-013dce81-cea5-487e-a88d-93b4420ef2d4.png">
