### PR TITLE
NR-11779: SVG and css for GetFooter section aligned with newrelic

### DIFF
--- a/src/components/GetStartedFooter.js
+++ b/src/components/GetStartedFooter.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { css } from '@emotion/react';
 import AnimatedText from './AnimatedText';
+import DoubleUnderlineSVG from './Icons/DoubleUnderlineSVG'
 
 const MOBILE_BREAKPOINT = '800px';
 
@@ -35,7 +36,7 @@ const GetStartedFooter = ({
         height: 120px;
 
         display: flex;
-        justify-content: space-evenly;
+        justify-content: center;
         align-items: center;
 
         font-size: 33px;
@@ -49,20 +50,44 @@ const GetStartedFooter = ({
           font-size: 44px;
           line-height: 50px;
           letter: -1.5%;
+         
         }
 
         @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-          height: 315px;
+          padding: 4rem 2.5rem 4rem 2.5rem;
+          height: 425px;
           flex-direction: column;
 
           > h3 {
-            margin-top: 34px;
             width: 296px;
             font-size: 36px;
-            line-height: 40px;
+            line-height: 2.875rem;
             line-spacing: -0.015em;
+            margin-bottom: 3.375rem;
+            font-size: 2.75rem;
+            letter-spacing: -0.015em;
+           
+          }
+
+          .Underline {
+            left: 0;
+            top: 100%;
+            position: absolute;
+            width: 100%;
           }
         }
+
+        @media screen and (min-width: ${MOBILE_BREAKPOINT}) {
+          h3 {
+          padding-right: 180px;
+          }
+        .Underline {
+          position: absolute;
+          right: 0;
+          width: 100%;
+          display: block;
+        }
+      }
       `}
     >
       <h3
@@ -70,7 +95,15 @@ const GetStartedFooter = ({
           margin-bottom: 0px;
         `}
       >
-        Get started today for free.
+        Get started today&nbsp;
+        <span
+        css={css`
+        white-space: nowrap;
+        position: relative;
+        `}>
+        for free.
+          <DoubleUnderlineSVG className="Underline" />
+          </span>
       </h3>
       <div
         css={css`
@@ -122,7 +155,7 @@ const GetStartedFooter = ({
               : '--brand-secondary-text-color'}
         );
           background-color: var(
-              --nr1--color--background--button--primary--enabled
+              --background-color
             );
             color: var(--nr1--color--text--buttton--primary);
         border-radius: 4px;
@@ -133,7 +166,7 @@ const GetStartedFooter = ({
 
           &:hover {
               background-color: var(
-                --nr1--color--background--button--primary--hover
+                --background-color
               );
               color: var(--nr1--color--text--buttton--primary);
             }
@@ -162,7 +195,7 @@ const GetStartedFooter = ({
               : '--brand-secondary-text-color'}
           );
           background-color: var(
-                --nr1--color--background--button--primary-accent--enabled
+            --btn-background-green
               );
               color: var(--nr1--color--text--buttton--primary-accent);
               border: 1px solid var(--nr1--color--text--buttton--primary-accent);
@@ -174,7 +207,7 @@ const GetStartedFooter = ({
   
             &:hover {
                 background-color: var(
-                  --nr1--color--background--button--primary-accent--hover
+                  --btn-background-green
                 );
                 color: var(--nr1--color--text--buttton--primary-accent);
               }

--- a/src/components/Icons/DoubleUnderlineSVG.js
+++ b/src/components/Icons/DoubleUnderlineSVG.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const DoubleUnderlineSVG = () => {
+    return (
+        <svg width="165" height="7" viewBox="0 0 165 7" fill="none" xmlns="http://www.w3.org/2000/svg" className="Underline">
+            <path d="M164.08 0.5C-187.52 0.5 137.22 6.01996 137.22 6.01996" stroke="#1D252C" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+    );
+};
+
+export default DoubleUnderlineSVG;


### PR DESCRIPTION
JIRA: https://issues.newrelic.com/browse/NR-10879
subtask: https://issues.newrelic.com/browse/NR-11779
Description:
1. Added one new svg component for Underline image
2. Added span for 'for free and underline section
3. Added media query for other than mobile screen
4. added same background color for hover of both buttons
5. Alignment of GetStartedFooter in web and mobile view - set padding and removed margin

Before changes:
<img width="1680" alt="Screenshot 2022-05-20 at 5 33 55 PM" src="https://user-images.githubusercontent.com/101187392/169524575-a2e996fb-fce3-4456-a03c-3e9e0d76cc64.png">

<img width="1680" alt="Screenshot 2022-05-20 at 5 34 20 PM" src="https://user-images.githubusercontent.com/101187392/169524588-34e98002-1247-4293-9c3b-08c47bde98f2.png">

*******
After Change
*******
<img width="1680" alt="Screenshot 2022-05-20 at 5 23 34 PM" src="https://user-images.githubusercontent.com/101187392/169531528-4d339c9f-8e08-4fae-a88a-0c18ff7dad3b.png">

<img width="1680" alt="Screenshot 2022-05-20 at 5 25 05 PM" src="https://user-images.githubusercontent.com/101187392/169531604-3aaba91f-ad18-4519-bde7-1789677ab7e1.png">



