### PR TITLE
NR-12727 - added space after copyright - mobile view

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
@@ -356,6 +356,7 @@ const GlobalFooter = ({ className }) => {
               @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
                 margin-top: 2rem;
                 margin-left: 40px;
+                margin-bottom: 2rem;
               }
             `}
           >


### PR DESCRIPTION
JIRA ticket: https://issues.newrelic.com/browse/NR-12727

Description: Added space after copyright section on mobile view

Previous: 
<img width="419" alt="image" src="https://user-images.githubusercontent.com/99316285/169539083-5ecc1cad-719e-4b8f-a339-0b7c4abc0fcd.png">

Now:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/99316285/169539033-fca3a69b-8854-4867-85e8-3d9e8b0308f5.png">

