### PR TITLE
fix/padding-on-landing-screen

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -384,7 +384,7 @@ const QuickstartsPage = ({ data, location }) => {
         <div
           css={css`
             grid-area: main;
-            padding: var(--site-content-padding);
+            padding: 1.5rem;
           `}
         >
           <div


### PR DESCRIPTION
Description: Observed that the landing page is having issue with the padding

Previous:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/99316285/169957504-e1734de9-2a12-402b-b1d8-9864bf6e50c5.png">

Now:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/99316285/169957541-4f0c5973-ff1f-4593-9d63-9245b273fcb3.png">

