### PR TITLE
NR-11587: show images on banner as per figma

### DIFF
--- a/src/components/IOBanner.js
+++ b/src/components/IOBanner.js
@@ -172,7 +172,7 @@ const IOBanner = ({ search, setSearch, setIsSearchInputEmpty }) => {
           css={css`
             margin-right: auto;
 
-            @media (max-width: 1310px) {
+            @media (max-width: 1439px) {
               display: none;
             }
           `}
@@ -199,7 +199,7 @@ const IOBanner = ({ search, setSearch, setIsSearchInputEmpty }) => {
           css={css`
             margin-left: auto;
 
-            @media (max-width: 1310px) {
+            @media (max-width: 1439px) {
               display: none;
             }
           `}

--- a/src/components/IOBanner.js
+++ b/src/components/IOBanner.js
@@ -172,7 +172,7 @@ const IOBanner = ({ search, setSearch, setIsSearchInputEmpty }) => {
           css={css`
             margin-right: auto;
 
-            @media (max-width: 1440px) {
+            @media (max-width: 1310px) {
               display: none;
             }
           `}
@@ -199,7 +199,7 @@ const IOBanner = ({ search, setSearch, setIsSearchInputEmpty }) => {
           css={css`
             margin-left: auto;
 
-            @media (max-width: 1440px) {
+            @media (max-width: 1310px) {
               display: none;
             }
           `}


### PR DESCRIPTION
JIRA ticket: https://issues.newrelic.com/browse/NR-11587

Description: Fixed the banner of the landing page as per the figma design

Figma design: https://www.figma.com/file/Orm0Ro7Zq4Y76jOnBwZW6B/Instant-Observability-I%2FO-v1?node-id=0%3A1

Previous: 
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/99316285/169994209-34cf5be2-cdd5-4468-8f18-87053213fde9.png">

Now:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/99316285/169994283-520d42a7-336c-4075-b7e5-a23282d08899.png">

