### PR TITLE
fix/NR-12565: Tile Bug in Homepage

### DIFF
--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -140,6 +140,7 @@ const QuickstartTile = ({
       <div
         css={css`
           grid-area: text;
+          overflow-wrap: anywhere;
         `}
       >
         <h4


### PR DESCRIPTION
**JIRA ticket**: https://issues.newrelic.com/browse/NR-12565

**Description**: Updated When I search for 'redis' in search, I'm able to find the Redis integration tile which is overlapping the tile in the right hand side.

**steps to testing**:
1. open the newrelic.com/instant-observability
2. click the searching box and type for "redis"

**before image**:
<img width="1104" alt="Screenshot 2022-05-24 at 3 42 00 PM" src="https://user-images.githubusercontent.com/106150577/170008242-7004bb9a-f4ec-4f2c-8b4c-ac4ec2fc3831.png">

**after image**:
<img width="1120" alt="Screenshot 2022-05-24 at 3 42 18 PM" src="https://user-images.githubusercontent.com/106150577/170008298-bb70d425-5ea4-4804-b31c-d74f4e6e5765.png">
