### PR TITLE
NR-12565: Tile Bug in Home Page

### DIFF
--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -140,6 +140,7 @@ const QuickstartTile = ({
       <div
         css={css`
           grid-area: text;
+          overflow-wrap: anywhere;
         `}
       >
         <h4


### PR DESCRIPTION
**JIRA ticket**: https://issues.newrelic.com/browse/NR-12565
**Description** : Updated  When I search for 'redis' in search, I'm able to find the Redis integration tile which is overlapping the tile in the right hand side.

**Steps to test**:
1. open the newrelic.com/instant-observability
2. click the search box and search the redis 

**before image**:
<img width="1104" alt="Screenshot 2022-05-24 at 3 42 00 PM" src="https://user-images.githubusercontent.com/106150577/170214224-4b4cd55e-48e2-4d4a-8819-28563158ad9f.png">
**After image**:
<img width="1120" alt="Screenshot 2022-05-24 at 3 42 18 PM" src="https://user-images.githubusercontent.com/106150577/170214286-2dd1803f-91ef-4d70-b198-234423bc247b.png">
