### PR TITLE
NR-12704: Fixed link color and button animations

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalFooter.js
@@ -88,7 +88,8 @@ const GlobalFooter = ({ className }) => {
         }
 
         a:hover {
-          color: white;
+          --tw-text-opacity: 1;
+          color: rgb(228 229 230 / var(--tw-text-opacity));
         }
       `}
     >
@@ -166,7 +167,8 @@ const GlobalFooter = ({ className }) => {
               grid-area: socials;
 
               svg:hover {
-                fill: white;
+                --tw-text-opacity: 1;
+                fill: rgb(228 229 230 / var(--tw-text-opacity));
               }
 
               @media screen and (min-width: calc(${MOBILE_BREAKPOINT} + 1px)) {

--- a/src/components/EmptyTab.js
+++ b/src/components/EmptyTab.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import { Button, Icon, Link } from '@newrelic/gatsby-theme-newrelic';
 import { QUICKSTARTS_REPO } from '../data/constants';
 import GitHubIconSVG from '../components/Icons/GitHubIconSVG';
+import AnimatedText from './AnimatedText';
 
 const EmptyTab = ({
   quickstartName,
@@ -44,7 +45,7 @@ const EmptyTab = ({
               background: var(--background-color);
               color: var(--btn-text-color);
               border-radius: 4px;
-              padding: 13.5px 20px 13.5px 22px;
+              padding: 0px 20px 0px 22px;
               column-gap: 14.45px; 
               
               &:hover{
@@ -55,6 +56,10 @@ const EmptyTab = ({
                 @media (max-width: 760px) {
                     width: 100%;
                 }
+              div {
+                text-align: left;
+                width: auto;
+              }
             `}
         as={Link}
         variant={Button.VARIANT.PRIMARY}
@@ -63,7 +68,9 @@ const EmptyTab = ({
         instrumentation={{ quickstartName }}
       >
         <GitHubIconSVG className="ViewRepo" />
-        View repo
+        <AnimatedText
+          text={'View repo'}
+        />
       </Button>
 
     </div>

--- a/src/components/LandingPageFooter.js
+++ b/src/components/LandingPageFooter.js
@@ -8,6 +8,7 @@ import ExternalLink from '@newrelic/gatsby-theme-newrelic/src/components/Externa
 import RelatedResources from './RelatedResources';
 import TickIconSVG from './Icons/TickIconSVG';
 import GitHubIconSVG from './Icons/GitHubIconSVG';
+import AnimatedText from './AnimatedText';
 
 const LandingPageFooter = ({
   quickstart,
@@ -100,15 +101,21 @@ const LandingPageFooter = ({
                 background: var(--background-color);
                 color: var(--btn-text-color);
                 border-radius: 4px;
-                padding: 13.5px 20px 13.5px 22px;
+                padding: 0px 20px 0px 22px;
+                border-color: var(--background-color);
                 column-gap: 14.45px;
                 font-weight: 400;
                 &:hover {
                   color: var(--white-hover-color);
+                  border-color: var(--background-color);
                 }
 
                 @media (max-width: 760px) {
                   width: 100%;
+                }
+                div {
+                  text-align: left;
+                  width: auto;
                 }
               `}
               as={Link}
@@ -118,7 +125,9 @@ const LandingPageFooter = ({
               onClick={trackQuickstart('QuickstartViewRepoClick', quickstart)}
             >
               <GitHubIconSVG className="ViewRepo" />
-              View repo
+              <AnimatedText
+                text={'View repo'}
+              />
             </Button>
           </div>
           <div
@@ -143,17 +152,24 @@ const LandingPageFooter = ({
                 column-gap: 14.45px;
                 font-weight: 400;
                 height: 48px;
+                border-color: var(--background-color);
                 &:hover {
                   color: var(--white-hover-color);
+                  border-color: var(--background-color);
                 }
 
                 @media (max-width: 760px) {
                   width: 100%;
                 }
+                div {
+                  text-align: left;
+                }
               `}
             >
               <TickIconSVG className="Tick" />
-              Build your own
+              <AnimatedText
+                text={'Build your own'}
+              />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
JIRA ticket: https://issues.newrelic.com/browse/NR-12704

Description:
1. When we mouse over a link, the colour is changing to grey in NR website. We need to sync with them.
2. View Repo & Build your own in the footer of the Public IO should have hover animation.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/99316285/170490898-16e949be-1235-4496-acd3-856e450339c3.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/99316285/170490931-416ca69f-e3ab-4245-b54f-ca5319a281be.png">

