### PR TITLE
NR-15360 applied spinner on "Install New Relic" button

### DIFF
--- a/src/components/GuidedInstallTileMostPopular.js
+++ b/src/components/GuidedInstallTileMostPopular.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import {
   Surface,
   Button,
   useInstrumentedHandler,
+  Spinner,
 } from '@newrelic/gatsby-theme-newrelic';
 import {
   SIGNUP_LINK,
@@ -15,6 +16,9 @@ import Cookies from 'js-cookie';
 import { getGuidedInstallStackedNr1Url } from '../utils/get-pack-nr1-url';
 
 const GuidedInstallTileMostPopular = () => {
+  // used to start the spinner on clicking "Install New Relic" button
+  const [startNavigation, setStartNavigation] = useState(false);
+
   const isReturningUser = Boolean(Cookies.get('ajs_user_id'));
 
   const handleNavigation = () => {
@@ -144,7 +148,10 @@ const GuidedInstallTileMostPopular = () => {
         `}
       >
         <Button
-          onClick={handleButtonClick}
+          onClick={() => {
+            setStartNavigation(true);
+            return handleButtonClick();
+          }}
           variant={Button.VARIANT.PRIMARY}
           size={Button.SIZE.SMALL}
           css={css`
@@ -160,6 +167,13 @@ const GuidedInstallTileMostPopular = () => {
           `}
         >
           Install New Relic
+          {startNavigation && (
+            <Spinner
+              css={css`
+                margin-left: 1rem;
+              `}
+            />
+          )}
         </Button>
       </div>
     </Surface>

--- a/src/components/GuidedInstallTileMostPopular.js
+++ b/src/components/GuidedInstallTileMostPopular.js
@@ -167,10 +167,17 @@ const GuidedInstallTileMostPopular = () => {
           `}
         >
           Install New Relic
-          {startNavigation && (
+          {true && (
             <Spinner
               css={css`
                 margin-left: 1rem;
+                :after {
+                  width: 2rem;
+                  height: 2rem;
+                  border-width: thick;
+                  display: flex;
+                  position: initial;
+                }
               `}
             />
           )}

--- a/src/components/GuidedInstallTileMostPopular.js
+++ b/src/components/GuidedInstallTileMostPopular.js
@@ -167,7 +167,7 @@ const GuidedInstallTileMostPopular = () => {
           `}
         >
           Install New Relic
-          {true && (
+          {startNavigation && (
             <Spinner
               css={css`
                 margin-left: 1rem;


### PR DESCRIPTION
JIRA ticket: https://issues.newrelic.com/browse/NR-15360

Description: Applied "Spinner" component on the "Install New Relic" button.

When user clicks on the button, user will see a spinner right next to "Install New Relic" and then the application will redirect to a new URL
