### PR TITLE
Add redirect for cloudflare

### DIFF
--- a/src/data/quickstart-redirects.json
+++ b/src/data/quickstart-redirects.json
@@ -1,6 +1,11 @@
 [
-    {
-      "to": "/netlify-builds/5861d7f5-26c0-43ad-bda8-c893c4b27b25",
-      "from": "/netlify/5861d7f5-26c0-43ad-bda8-c893c4b27b25"
-    }
-  ]
+  {
+    "to": "/netlify-builds/5861d7f5-26c0-43ad-bda8-c893c4b27b25",
+    "from": "/netlify/5861d7f5-26c0-43ad-bda8-c893c4b27b25"
+  },
+  {
+    "to": "/cloudflare-network-logs/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434",
+    "from": "/cloudflare/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434"
+  }
+]
+


### PR DESCRIPTION
# Summary
The cloudflare quickstart has changed it's slug in the past, this makes sure the older link is redirected to the correct one.