### PR TITLE
fix/image-alligned-to-left

### DIFF
--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -124,6 +124,7 @@ const QuickstartTile = ({
             packName={title || name}
             css={css`
               object-fit: scale-down;
+              object-position: left;
               height: 45px;
               margin: 35px 0 0;
 


### PR DESCRIPTION
JIRA Ticket: https://issues.newrelic.com/browse/NR-19346

Description:
Observed that few images on the quick start tiles are aligned to the center. Fixed it by aligning all the images to left

Prev:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/99316285/171099128-a4802f36-70ea-4158-9470-f2790ee3cd99.png">

Now:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/99316285/171099178-75084d5f-3feb-405d-b115-fac66ac63cd2.png">
