### PR TITLE
NR-20101 : tessen events on social buttons

### DIFF
--- a/src/components/Share.jsx
+++ b/src/components/Share.jsx
@@ -12,11 +12,24 @@ import LinkedinSVG from './Icons/LinkedinSVG';
 import MailSVG from './Icons/MailSVG';
 import { css } from '@emotion/react';
 import { MIN_WIDTH_BREAKPOINT } from '../data/constants';
+import { useTessen } from '@newrelic/gatsby-theme-newrelic';
 
-const Share = ({
-    url
-}) => (
 
+
+export default function Share({ url }) {
+    const tessen = useTessen();
+    const tessenOnShareClick = (value) => {
+
+        console.log({ value }, "comein")
+
+        tessen.track({
+            eventName: 'instantObservability',
+            category: 'TessenOnShareClick',
+            buttonClicked: value
+        });
+    };
+
+return (
     <div
         css={css`
         .button {
@@ -29,28 +42,29 @@ const Share = ({
         }
         `}
         className="post-social">
-        <FacebookShareButton url={url} className="button" >
+        <FacebookShareButton url={url} className="button" onClick={() => tessenOnShareClick('FaceBook')} >
             <FacebookSVG
                 width="24"
                 height="24"
             />
         </FacebookShareButton>
 
-        <TwitterShareButton url={url} className="button" >
+        <TwitterShareButton url={url} className="button" onClick={() => tessenOnShareClick('Twitter')}>
             <TwitterSVG width="24"
                 height="24" />
         </TwitterShareButton>
 
-        <LinkedinShareButton url={url} className="button">
+        <LinkedinShareButton url={url} className="button" onClick={() => tessenOnShareClick('Linkedin')}>
             <LinkedinSVG width="24"
                 height="24" />
         </LinkedinShareButton>
 
-        <EmailShareButton url={url} className="button" >
+        <EmailShareButton url={url} className="button" onClick={() => tessenOnShareClick('EmailShare')}>
             <MailSVG width="24"
                 height="24" />
         </EmailShareButton>
     </div>
 );
+    
+};
 
-export default Share;


### PR DESCRIPTION
**JIRA ticket**: https://issues.newrelic.com/browse/NR-20101

**Description**: Added tessen event for social sharing in Public IO quick-start pages

**Steps to test**:
1. open newrelic.com/instant-observability
2. User will see the main page and goto the details page
3. User will see "Share this" buttons
4. when we click a particle social media buttons, the tessen event will be captured
5. To see the captured event, click on query builder select this account (Account: 1478838 - Growth Data Team / TessenJS)
Run the query (  FROM TessenAction SELECT count(*) WHERE (eventName LIKE 'YOUR EVENT NAME')) to see the count of the event.
**example**:
FROM TessenAction SELECT  * WHERE eventName LIKE 'TIO_TessenOnShareClick_instantObservability' FACET buttonClicked

**Screen short of the query builder**:
<img width="1425" alt="Screenshot 2022-06-06 at 2 49 03 PM" src="https://user-images.githubusercontent.com/106150577/172133068-d6e3b79d-3120-438a-a208-85286556fb70.png">

