### PR TITLE
NR-20101 : tessen events on social buttons

### DIFF
--- a/src/components/Share.jsx
+++ b/src/components/Share.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
-    FacebookShareButton,
-    LinkedinShareButton,
-    TwitterShareButton,
-    EmailShareButton,
+  FacebookShareButton,
+  LinkedinShareButton,
+  TwitterShareButton,
+  EmailShareButton,
 } from 'react-share';
 
 import FacebookSVG from './Icons/FacebookSVG';
@@ -12,45 +12,71 @@ import LinkedinSVG from './Icons/LinkedinSVG';
 import MailSVG from './Icons/MailSVG';
 import { css } from '@emotion/react';
 import { MIN_WIDTH_BREAKPOINT } from '../data/constants';
+import PropTypes from 'prop-types';
+import { useTessen } from '@newrelic/gatsby-theme-newrelic';
 
-const Share = ({
-    url
-}) => (
-
+const Share = ({ url }) => {
+  const tessen = useTessen();
+  const tessenOnShareClick = (value) => {
+    // capturing  click events of share buttons
+    tessen.track({
+      eventName: 'instantObservability',
+      category: 'TessenOnShareClick',
+      shareButtonName: value,
+    });
+  };
+  return (
     <div
-        css={css`
+      css={css`
         .button {
-            margin-right: 0;
-            
-            @media (max-width: ${MIN_WIDTH_BREAKPOINT}) {
-                margin: 0;
-                margin-right: 3px;
-            }
+          margin-right: 0;
+
+          @media (max-width: ${MIN_WIDTH_BREAKPOINT}) {
+            margin: 0;
+            margin-right: 3px;
+          }
         }
-        `}
-        className="post-social">
-        <FacebookShareButton url={url} className="button" >
-            <FacebookSVG
-                width="24"
-                height="24"
-            />
-        </FacebookShareButton>
+      `}
+      className="post-social"
+    >
+      <FacebookShareButton
+        url={url}
+        className="button"
+        onClick={() => tessenOnShareClick('FaceBook')}
+      >
+        <FacebookSVG width="24" height="24" />
+      </FacebookShareButton>
 
-        <TwitterShareButton url={url} className="button" >
-            <TwitterSVG width="24"
-                height="24" />
-        </TwitterShareButton>
+      <TwitterShareButton
+        url={url}
+        className="button"
+        onClick={() => tessenOnShareClick('Twitter')}
+      >
+        <TwitterSVG width="24" height="24" />
+      </TwitterShareButton>
 
-        <LinkedinShareButton url={url} className="button">
-            <LinkedinSVG width="24"
-                height="24" />
-        </LinkedinShareButton>
+      <LinkedinShareButton
+        url={url}
+        className="button"
+        onClick={() => tessenOnShareClick('Linkedin')}
+      >
+        <LinkedinSVG width="24" height="24" />
+      </LinkedinShareButton>
 
-        <EmailShareButton url={url} className="button" >
-            <MailSVG width="24"
-                height="24" />
-        </EmailShareButton>
+      <EmailShareButton
+        url={url}
+        openShareDialogOnClick
+        className="button"
+        onClick={() => tessenOnShareClick('EmailShare')}
+      >
+        <MailSVG width="24" height="24" />
+      </EmailShareButton>
     </div>
-);
+  );
+};
+
+Share.propTypes = {
+  url: PropTypes.string,
+};
 
 export default Share;


### PR DESCRIPTION
**JIRA ticket**: https://issues.newrelic.com/browse/NR-20101

**Description**: Added tessen event for social sharing in Public IO quick-start pages

**Steps to test**:
1. open newrelic.com/instant-observability
2. User will see the main page and goto the details page
3. User will see "Share this" buttons
4. when we click a particle social media buttons, the tessen event will be captured
5. To see the captured event, click on query builder select this account (Account: 1478838 - Growth Data Team / TessenJS)
Run the query ( FROM TessenAction SELECT count(*) WHERE (eventName LIKE 'YOUR EVENT NAME')) to see the count of the event.
example:
FROM TessenAction SELECT * WHERE eventName LIKE 'TIO_TessenOnShareClick_instantObservability' FACET buttonClicked

**Screen short of the query builder**:

<img width="1440" alt="Screenshot 2022-06-02 at 4 43 08 PM" src="https://user-images.githubusercontent.com/106150577/172372662-062fa798-00d1-4454-a513-6481179f2f55.png">
