### PR TITLE
fix/dashboard-carousel-on-details-page

### DIFF
--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -45,43 +45,8 @@ const QuickstartDashboards = ({ quickstart }) => {
         `}
       />
     ),
-    responsive: [
-      {
-        // 4k resolution
-        breakpoint: 3840,
-        settings: {
-          slidesToShow: 3,
-          slidesToScroll: 1,
-          infinite: true,
-          dots: false,
-        },
-      },
-      {
-        breakpoint: 1081,
-        settings: {
-          slidesToShow: 1,
-          slidesToScroll: 1,
-          infinite: true,
-          dots: false,
-        },
-      },
-      {
-        breakpoint: 760,
-        settings: {
-          slidesToShow: 1,
-          slidesToScroll: 1,
-          infinite: true,
-          dots: false,
-        },
-      },
-      {
-        breakpoint: 480,
-        settings: {
-          slidesToShow: 1,
-          slidesToScroll: 1,
-        },
-      },
-    ],
+    // the carousel is acting responsive by default
+    responsive: [],
   };
 
   const renderDescription = (dashboard) => {


### PR DESCRIPTION
Description: Fixed the carousel UI on details page of quickstart

Previous:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/99316285/175263883-58fbde91-4fb8-47f9-94c0-7486ebff1210.png">

Now:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/99316285/175263959-d84e0873-4bff-42c8-b8b7-07458a56d13f.png">

