### PR TITLE
NR-21569 invalid category breaks page

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -191,7 +191,7 @@ const QuickstartsPage = ({ data, location }) => {
   const getDisplayName = (defaultName = 'All quickstarts') => {
     const found = CATEGORIES.find((cat) => cat.value === category);
 
-    if (!found.value) return defaultName;
+    if (!found || !found.value) return defaultName;
 
     return found.displayName;
   };


### PR DESCRIPTION
Just checking !found as well as !found.value fixes the page from breaking.  This still leaves the invalid category in the URL.  There doesn't seem to be a fix for that outside of refreshing the page if the category is invalid.  We could try to go that route but i think it would need to be done in the useEffect which seems like it could get hacky. Another possible option is where we display the category title or 'All quickstarts' as the default label, if we receive an invalid category we could throw some text in that says this category was invalid, etc.

https://issues.newrelic.com/browse/NR-21569