### PR TITLE
Changes to page pathname close mobile menu

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import AnnouncementBanner from '@newrelic/gatsby-theme-newrelic/src/components/AnnouncementBanner';
@@ -84,9 +84,9 @@ const GlobalHeader = ({ className, activeSite }) => {
   const hasChangedPage = location.pathname !== previousLocation?.pathname;
   const UserIsInMainPage = location.pathname === '/instant-observability/';
   const showGetStarted = !!UserIsInMainPage;
-  const [isOpen, setOpen] = React.useState(false);
+  const [isOpen, setOpen] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isOpen) {
       document.body.style.overflowY = 'hidden';
     } else {
@@ -94,7 +94,7 @@ const GlobalHeader = ({ className, activeSite }) => {
     }
   }, [isOpen]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isOpen && hasChangedPage) {
       setOpen(!isOpen);
     }

--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
@@ -7,7 +7,10 @@ import Button from '@newrelic/gatsby-theme-newrelic/src/components/Button';
 import GlobalNavLink from '@newrelic/gatsby-theme-newrelic/src/components/GlobalNavLink';
 import useMedia from 'use-media';
 import useThemeTranslation from '@newrelic/gatsby-theme-newrelic/src/hooks/useThemeTranslation';
-import { useInstrumentedHandler } from '@newrelic/gatsby-theme-newrelic';
+import {
+  useInstrumentedHandler,
+  usePrevious,
+} from '@newrelic/gatsby-theme-newrelic';
 import { Menu, X } from 'react-feather';
 import { useLocation } from '@reach/router';
 import NewLogo from './NewLogo';
@@ -75,6 +78,12 @@ const MOBILE_BREAKPOINT = '600px';
 
 const GlobalHeader = ({ className, activeSite }) => {
   const { t } = useThemeTranslation();
+  const hideLogoText = useMedia({ maxWidth: '350px' });
+  const location = useLocation();
+  const previousLocation = usePrevious(location);
+  const hasChangedPage = location.pathname !== previousLocation?.pathname;
+  const UserIsInMainPage = location.pathname === '/instant-observability/';
+  const showGetStarted = !!UserIsInMainPage;
   const [isOpen, setOpen] = React.useState(false);
 
   React.useEffect(() => {
@@ -85,10 +94,11 @@ const GlobalHeader = ({ className, activeSite }) => {
     }
   }, [isOpen]);
 
-  const hideLogoText = useMedia({ maxWidth: '350px' });
-  const location = useLocation();
-  const UserIsInMainPage = location.pathname === '/instant-observability/';
-  const showGetStarted = !!UserIsInMainPage;
+  React.useEffect(() => {
+    if (isOpen && hasChangedPage) {
+      setOpen(!isOpen);
+    }
+  }, [hasChangedPage, setOpen, isOpen]);
 
   return (
     <>


### PR DESCRIPTION
The header now detects when a user clicks the back button while the mobile menu overlay is open and closes it while navigating.

I chose to use the logic in the gatsby-theme-newrelic [MobileNavigation](https://github.com/newrelic/gatsby-theme-newrelic/blob/develop/packages/gatsby-theme-newrelic/src/components/MobileNavigation.js) component. I was having a lot of styling issues come up when trying to import the component directly. 

I was seeing odd behavior in the local server where sometimes when clicking the hamburger icon, I would have to click it twice to get the overlay to open. I can't seem to reproduce it in a build, so please check this when reviewing.