### PR TITLE
Sort quickstart components by available content

### DIFF
--- a/src/components/WhatsIncluded/WhatsIncludedHeader.jsx
+++ b/src/components/WhatsIncluded/WhatsIncludedHeader.jsx
@@ -15,12 +15,12 @@ const WhatsIncludedHeader = () => {
         display: grid;
         grid-template-columns: repeat(auto, 1fr);
         grid-auto-flow: column;
-        padding-top: 3rem;
+        margin-top: 3rem;
 
         @media (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
           grid-template-columns: repeat(1, 1fr);
           grid-template-rows: repeat(2, 40px);
-          margin-bottom: 1rem;
+          margin-bottom: 3rem;
         }
       `}
     >

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -27,22 +27,28 @@ const layoutContentSpacing = css`
 `;
 
 const moveToBack = (componentsAndCounts) => {
+  const n = componentsAndCounts.length;
   const newOrder = [];
 
-  // traverse array from back to front
-  // to remain same order of components for render.
-  let i = componentsAndCounts.length - 1;
-
-  while (i >= 0) {
-    if (componentsAndCounts[i].count === 0) {
+  // add components with content
+  // to the beginning of array
+  let i = 0;
+  while (i < n) {
+    if (componentsAndCounts[i].count !== 0) {
       // Push element to end of array.
       // This keeps the same order if all components
       // have a length of 0.
-      newOrder.push(componentsAndCounts[i--]);
-    } else {
-      // if there are components, add to the front of the array
-      newOrder.unshift(componentsAndCounts[i--]);
+      newOrder.push(componentsAndCounts.splice(i, 1)[0]);
     }
+    i++;
+  }
+
+  // add components without content
+  // to the end of array
+  while (componentsAndCounts.length > 0) {
+    // push the remaining elements in order to
+    // new ordered array
+    newOrder.push(componentsAndCounts.shift());
   }
   return newOrder;
 };

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -26,6 +26,56 @@ const layoutContentSpacing = css`
   margin: auto;
 `;
 
+const moveToBack = (componentsAndCounts) => {
+  const newOrder = [];
+
+  // traverse array from back to front
+  // to remain same order of components for render.
+  let i = componentsAndCounts.length - 1;
+
+  while (i >= 0) {
+    if (componentsAndCounts[i].count === 0) {
+      // Push element to end of array.
+      // This keeps the same order if all components
+      // have a length of 0.
+      newOrder.push(componentsAndCounts[i--]);
+    } else {
+      // if there are components, add to the front of the array
+      newOrder.unshift(componentsAndCounts[i--]);
+    }
+  }
+  return newOrder;
+};
+
+const sortOrderedQuickstartComponents = (quickstart) => {
+  // get length of all components
+  const dashboardLength = quickstart.dashboards?.length ?? 0;
+  const alertLength = quickstart.alerts?.length ?? 0;
+
+  // we use documentation for datasources at the moment
+  const dataSourceLength = quickstart.documentation?.length ?? 0;
+
+  // sort by length
+  const componentsAndCounts = [
+    {
+      component: Dashboards,
+      count: dashboardLength,
+    },
+    { component: Alerts, count: alertLength },
+    { component: DataSources, count: dataSourceLength },
+  ];
+
+  // Check to see if we need to move empty components to
+  // the end of the array
+  const hasEmptyComponent = componentsAndCounts.filter(
+    (component) => component.count
+  );
+
+  return hasEmptyComponent.length > 0
+    ? moveToBack(componentsAndCounts)
+    : componentsAndCounts;
+};
+
 const QuickstartDetails = ({ data, location }) => {
   const quickstart = data.quickstarts;
   const tessen = useTessen();
@@ -95,13 +145,17 @@ const QuickstartDetails = ({ data, location }) => {
           css={css`
             ${layoutContentSpacing};
             > * {
+              :first-child {
+                padding-top: 0px;
+              }
+
               padding-top: 3rem;
             }
           `}
         >
-          <Dashboards quickstart={quickstart} />
-          <Alerts quickstart={quickstart} />
-          <DataSources quickstart={quickstart} />
+          {sortOrderedQuickstartComponents(quickstart).map((obj, index) => (
+            <obj.component key={index} quickstart={quickstart} />
+          ))}
         </div>
         <div
           css={css`

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -136,10 +136,10 @@ const QuickstartDetails = ({ data, location }) => {
           css={css`
             ${layoutContentSpacing};
             > * {
-              padding-bottom: 2rem;
+              margin-bottom: 1rem;
 
               @media (min-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-                padding-bottom: 1rem;
+                margin-bottom: 3rem;
               }
             }
           `}

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -26,31 +26,21 @@ const layoutContentSpacing = css`
   margin: auto;
 `;
 
-const moveToBack = (componentsAndCounts) => {
-  const n = componentsAndCounts.length;
-  const newOrder = [];
-
-  // add components with content
-  // to the beginning of array
-  let i = 0;
-  while (i < n) {
-    if (componentsAndCounts[i].count !== 0) {
-      // Push element to end of array.
-      // This keeps the same order if all components
-      // have a length of 0.
-      newOrder.push(componentsAndCounts.splice(i, 1)[0]);
-    }
-    i++;
+/*
+ * Callback function for sorting data sources and
+ * prioritizing default ordering
+ * @param {Object} a - Object with react component and length of quickstart component
+ * @param {Object} b - Object with react component and length of quickstart component
+ * @returns number
+ */
+const sortComponents = (a, b) => {
+  if (a.count < 1) {
+    return 1;
+  } else if (b.count < 1) {
+    return -1;
+  } else {
+    return 0;
   }
-
-  // add components without content
-  // to the end of array
-  while (componentsAndCounts.length > 0) {
-    // push the remaining elements in order to
-    // new ordered array
-    newOrder.push(componentsAndCounts.shift());
-  }
-  return newOrder;
 };
 
 const sortOrderedQuickstartComponents = (quickstart) => {
@@ -71,15 +61,7 @@ const sortOrderedQuickstartComponents = (quickstart) => {
     { component: DataSources, count: dataSourceLength },
   ];
 
-  // Check to see if we need to move empty components to
-  // the end of the array
-  const hasEmptyComponent = componentsAndCounts.filter(
-    (component) => component.count
-  );
-
-  return hasEmptyComponent.length > 0
-    ? moveToBack(componentsAndCounts)
-    : componentsAndCounts;
+  return componentsAndCounts.sort(sortComponents);
 };
 
 const QuickstartDetails = ({ data, location }) => {

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -136,11 +136,7 @@ const QuickstartDetails = ({ data, location }) => {
           css={css`
             ${layoutContentSpacing};
             > * {
-              margin-bottom: 1rem;
-
-              @media (min-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-                margin-bottom: 3rem;
-              }
+              margin-bottom: 3rem;
             }
           `}
         >

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -16,7 +16,6 @@ import DataSources from '@components/WhatsIncluded/DataSources';
 import Layout from '@components/Layout';
 import QuickstartOverview from '@components/QuickstartOverview';
 import LandingBanner from '@components/LandingBanner';
-import { QUICKSTARTS_COLLAPSE_BREAKPOINT } from '@data/constants';
 
 const layoutContentSpacing = css`
   --page-margin: 156px;

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -151,10 +151,6 @@ const QuickstartDetails = ({ data, location }) => {
           css={css`
             ${layoutContentSpacing};
             > * {
-              :first-child {
-                padding-top: 0px;
-              }
-
               padding-top: 3rem;
             }
           `}


### PR DESCRIPTION
## Summary

This PR serves the purpose of rendering the component sections of the Landing Page with content _before_ the sections without content.

> NOTE: Currently, the `Dashboards.jsx` file has the "What's included?" header inside of the component. There will be another PR to address that change. Example of header issues below.

#### Example

<img width="1017" alt="Screen Shot 2022-07-06 at 1 14 56 PM" src="https://user-images.githubusercontent.com/56952981/177635302-8e5e11e8-0d30-4c45-8294-f7f527564a8c.png">

### Considerations
- As mentioned above, there will be another PR for React/CSS changes. That PR will be merged into this `feat` branch so that both changes are merged to `main` at the same time.




### New Expected Behavior:
1. `Dashboards(0)`, `Alerts(0)`, `Data Sources(1)` -> `Data Sources(1)`, `Dashboards(0)`, `Alerts(0)`
2. `Dashboards(1)`, `Alerts(2)`, `Data Sources(1)` ->  `Dashboards(1)`, `Alerts(2)`, `Data Sources(1)`
3. `Dashboards(0)`, `Alerts(2)`, `Data Sources(1)` ->  `Alerts(2)`, `Data Sources(1)`, `Dashboards(0)`, 