### PR TITLE
Slick carousel improvements

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
@@ -517,7 +517,7 @@ const GlobalHeader = ({ className, activeSite }) => {
             width: 100vw;
             height: 100vh;
             background-color: var(--color-white);
-            z-index: 10;
+            z-index: 200;
 
             @media screen and (min-width: 1128px) {
               display: none;

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -41,7 +41,6 @@ const Overlay = ({ children, onCloseOverlay, isOpen = false, className }) => {
       <div
         ref={ref}
         css={css`
-          z-index: 1000;
           position: fixed;
           top: 0;
           left: 0;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -87,8 +87,6 @@ const QuickstartsPage = ({ data, location }) => {
   const [isCategoriesOverlayOpen, setIsCategoriesOverlayOpen] = useState(false);
   const [isSearchInputEmpty, setIsSearchInputEmpty] = useState(true);
   const [isSelectCategory, setIsSelectCategory] = useState(true);
-  // variable to check if the page load completed
-  const [loadComplete, setLoadComplete] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -107,11 +105,6 @@ const QuickstartsPage = ({ data, location }) => {
       });
     }
   }, [location.search, tessen]);
-
-  // mark the value as true, if the page is loaded
-  useEffect(() => {
-    setLoadComplete(true);
-  }, []);
 
   const closeCategoriesOverlay = () => {
     setIsCategoriesOverlayOpen(false);
@@ -604,24 +597,21 @@ const QuickstartsPage = ({ data, location }) => {
                     </span>
                   </div>
                   <div>
-                    {!loadComplete && <Spinner />}
-                    {loadComplete && (
-                      <Slider
-                        {...settings}
-                        css={css`
-                          display: flex;
-                        `}
-                      >
-                        <SuperTiles />
-                        {mostPopularQuickStarts.map((pack) => (
-                          <QuickstartTile
-                            key={pack.id}
-                            featured={false}
-                            {...pack}
-                          />
-                        ))}
-                      </Slider>
-                    )}
+                    <Slider
+                      {...settings}
+                      css={css`
+                        display: flex;
+                      `}
+                    >
+                      <SuperTiles />
+                      {mostPopularQuickStarts.map((pack) => (
+                        <QuickstartTile
+                          key={pack.id}
+                          featured={false}
+                          {...pack}
+                        />
+                      ))}
+                    </Slider>
                   </div>
                 </>
               )}
@@ -655,18 +645,11 @@ const QuickstartsPage = ({ data, location }) => {
                   margin-bottom: 75px;
                 `}
               >
-                {!loadComplete && <Spinner />}
-                {loadComplete && (
-                  <Slider {...settings}>
-                    {featuredQuickStarts.map((pack) => (
-                      <QuickstartTile
-                        key={pack.id}
-                        featured={false}
-                        {...pack}
-                      />
-                    ))}
-                  </Slider>
-                )}
+                <Slider {...settings}>
+                  {featuredQuickStarts.map((pack) => (
+                    <QuickstartTile key={pack.id} featured={false} {...pack} />
+                  ))}
+                </Slider>
               </div>
             </>
           )}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -2,12 +2,7 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '@components/styles.scss';
 
-import {
-  Button,
-  Icon,
-  Spinner,
-  useTessen,
-} from '@newrelic/gatsby-theme-newrelic';
+import { Button, Icon, useTessen } from '@newrelic/gatsby-theme-newrelic';
 import React, { useEffect, useState } from 'react';
 
 import CATEGORIES from '@data/instant-observability-categories';


### PR DESCRIPTION
Removed spinner element and loadComplete logic that was causing the layout shift on the carousel components.

Also, there was a minor bug were the arrow button was visible over the mobile overlay menu in some screen sizes. That has also been resolved in this ticket.

<details>
  <summary> <i>Example of the UI bug before fix</i> </summary>
<img width="731" alt="Screen Shot 2022-07-07 at 1 48 34 PM" src="https://user-images.githubusercontent.com/47728020/177870293-a3185044-c003-405c-aacb-cd593d3852ab.png">
</details>
 