### PR TITLE
Reduce Slick carousel layout shift

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/GlobalHeader.js
@@ -517,7 +517,7 @@ const GlobalHeader = ({ className, activeSite }) => {
             width: 100vw;
             height: 100vh;
             background-color: var(--color-white);
-            z-index: 10;
+            z-index: 200;
 
             @media screen and (min-width: 1128px) {
               display: none;

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -41,7 +41,6 @@ const Overlay = ({ children, onCloseOverlay, isOpen = false, className }) => {
       <div
         ref={ref}
         css={css`
-          z-index: 1000;
           position: fixed;
           top: 0;
           left: 0;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -603,7 +603,11 @@ const QuickstartsPage = ({ data, location }) => {
                       <strong>Most Popular</strong>
                     </span>
                   </div>
-                  <div>
+                  <div
+                    css={css`
+                      height: 362px;
+                    `}
+                  >
                     {!loadComplete && <Spinner />}
                     {loadComplete && (
                       <Slider
@@ -653,6 +657,7 @@ const QuickstartsPage = ({ data, location }) => {
               <div
                 css={css`
                   margin-bottom: 75px;
+                  height: 362px;
                 `}
               >
                 {!loadComplete && <Spinner />}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -30,6 +30,8 @@ const TRIPLE_COLUMN_BREAKPOINT = '1420px';
 const DOUBLE_COLUMN_BREAKPOINT = '1180px';
 const SINGLE_COLUMN_BREAKPOINT = '900px';
 const COLUMN_BREAKPOINT = '1131px';
+//used to set the height of the Spinner to reduce layout shift on page load
+const TILE_HEIGHT = '362px';
 
 /**
  * Determines if one string is a substring of the other, case insensitive
@@ -206,7 +208,7 @@ const QuickstartsPage = ({ data, location }) => {
     adaptiveWidth: true,
     mobileFirst: true, // necessary for breakpoints to work as expected
     prevArrow: (
-      <button>
+      <button type="button">
         <LeftArrowSVG
           className="slick-prev"
           css={css`
@@ -218,7 +220,7 @@ const QuickstartsPage = ({ data, location }) => {
       </button>
     ),
     nextArrow: (
-      <button>
+      <button type="button">
         <RightArrowSVG
           className="slick-next"
           css={css`
@@ -605,7 +607,7 @@ const QuickstartsPage = ({ data, location }) => {
                   </div>
                   <div
                     css={css`
-                      height: 362px;
+                      height: ${TILE_HEIGHT};
                     `}
                   >
                     {!loadComplete && <Spinner />}
@@ -657,7 +659,7 @@ const QuickstartsPage = ({ data, location }) => {
               <div
                 css={css`
                   margin-bottom: 75px;
-                  height: 362px;
+                  height: ${TILE_HEIGHT};
                 `}
               >
                 {!loadComplete && <Spinner />}


### PR DESCRIPTION
Added a bigger height to the Spinner component that matches the size of the QuickstartTiles to reduce the layout shift on the carousel.

- Performance scores show layout shift for Desktop improves from 0.07 to 0.0

Also, there was a minor bug were the arrow button was visible over the mobile overlay menu in some screen sizes. That has also been resolved in this ticket.

<details>
  <summary> <i>Example of the UI bug before fix</i> </summary>
<img width="731" alt="Screen Shot 2022-07-07 at 1 48 34 PM" src="https://user-images.githubusercontent.com/47728020/177870293-a3185044-c003-405c-aacb-cd593d3852ab.png">
</details>
 
