### PR TITLE
Quickstart tile summary overlap

### DIFF
--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -64,6 +64,7 @@ const QuickstartTile = ({
       css={css`
         --tile-image-height: 100px; /* Logo image height */
         --title-row-height: auto; /* Title height to allow space for longer string */
+        --tile-content-height: 180px;
         padding: 0 22px 35px 24px;
         overflow: hidden;
         height: 360px;
@@ -95,7 +96,7 @@ const QuickstartTile = ({
         display: grid;
         align-items: flex-start;
         grid-gap: 0.2rem;
-        grid-template-rows: var(--tile-image-height) 152px auto;
+        grid-template-rows: var(--tile-image-height) var(--tile-content-height) auto;
         grid-template-columns: auto;
         grid-template-areas:
           'logo logo'
@@ -141,12 +142,14 @@ const QuickstartTile = ({
       <div
         css={css`
           grid-area: text;
-          overflow-wrap: anywhere;
+          height: var(--tile-content-height);
+          overflow: hidden;
+          display: flex;
+          flex-flow: column wrap;
         `}
       >
         <h4
           css={css`
-            grid-area: title;
             font-weight: normal;
             font-size: 24px;
             letter-spacing: -0.5%;
@@ -156,12 +159,7 @@ const QuickstartTile = ({
           {SHIELD_LEVELS.includes(level) && <Icon name="nr-check-shield" />}
         </h4>
 
-        <div
-          css={css`
-            grid-area: summary;
-            align-self: flex-start;
-          `}
-        >
+        <div>
           <p
             css={css`
               font-size: 18px;


### PR DESCRIPTION
# Summary
Fixes the issue where long quickstart title can cause the summary to overlap the "read more" button. I opted for a CSS based approach instead of Javascript because counting the number of characters in the title and showing/hiding the summary based on that introduces way too many edge cases around changing letter spacing and line spacing.

The CSS approach has one issue, a few tiles that had no overlap now have their summaries hidden. This is because they were already breaking out of their containers, but the title isn't long enough to cause the "read more" overlap. 
### Before
<img width="287" alt="Screen Shot 2022-07-11 at 3 40 36 PM" src="https://user-images.githubusercontent.com/70179303/178371313-898fdf8d-e359-40c1-a03d-cdec514aa1fa.png">

### After
<img width="282" alt="Screen Shot 2022-07-11 at 3 40 30 PM" src="https://user-images.githubusercontent.com/70179303/178371333-1978cf6c-5405-4b38-98e9-bd5b6fb756d1.png">
