### PR TITLE
Fix SVG errors during development & builds

### DIFF
--- a/plugins/gatsby-source-quickstarts/gatsby-node.js
+++ b/plugins/gatsby-source-quickstarts/gatsby-node.js
@@ -50,6 +50,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       summary: String
       keywords: [String]
       authors: [String]
+      logoSvg: File
       logo: File
       level: QuickstartSupportLevel
       documentation: [QuickstartDocumentation]
@@ -145,6 +146,8 @@ exports.sourceNodes = async ({
         console.log(`Unable to fetch logo for ${name}: ${logoUrl}`); // eslint-disable-line no-console
       }
 
+      const isLogoSvg = logoNode && logoNode.ext === '.svg';
+
       // loop over the dashboard(s) for this quickstart, fetch all the
       // screenshot(s) and create "File" nodes for each.
       const dashboards = await Promise.all(
@@ -173,7 +176,8 @@ exports.sourceNodes = async ({
         documentation: quickstart.documentation,
         alerts: quickstart.alerts,
         installPlans: quickstart.installPlans,
-        logo: logoNode || null,
+        logo: !isLogoSvg ? logoNode : null,
+        logoSvg: isLogoSvg ? logoNode : null,
         dashboards,
         // gatsby fields
         parent: null,

--- a/src/components/LandingBanner/index.js
+++ b/src/components/LandingBanner/index.js
@@ -69,7 +69,7 @@ const LandingBanner = ({ quickstart, className, location }) => {
         `}
       >
         <Breadcrumbs segments={breadcrumbs} />
-        {quickstart.logo && (
+        {(quickstart.logo || quickstart.logoSvg) && (
           <div
             css={css`
               position: absolute;
@@ -94,6 +94,7 @@ const LandingBanner = ({ quickstart, className, location }) => {
               <QuickstartImg
                 packName={quickstart.name}
                 imageNode={quickstart.logo}
+                svgNode={quickstart.logoSvg}
                 css={css`
                   max-width: 350px;
                   margin: auto;

--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -50,7 +50,7 @@ FallbackImg.propTypes = {
   className: PropTypes.string,
 };
 
-const QuickstartImg = ({ className, packName, imageNode }) => {
+const QuickstartImg = ({ className, packName, imageNode, svgNode }) => {
   if (imageNode) {
     // If we have an image for sharp to optimize, use GatsbyImage
     const image = getImage(imageNode);
@@ -69,25 +69,23 @@ const QuickstartImg = ({ className, packName, imageNode }) => {
         />
       );
     }
+  }
 
-    // If we don't have a sharp-capable image, but we have a URL, it's an
-    // SVG (already performant) and is already built with the site.
-    const { ext, publicURL } = imageNode;
-
-    if (ext === '.svg' && publicURL) {
-      return (
-        <img
-          css={css`
-            display: block;
-            max-width: 100%;
-            max-height: 100%;
-          `}
-          src={publicURL}
-          alt={packName}
-          className={className}
-        />
-      );
-    }
+  // If we don't have a sharp-capable image, but we have a URL, it's an
+  // SVG (already performant) and is already built with the site.
+  if (svgNode) {
+    return (
+      <img
+        css={css`
+          display: block;
+          max-width: 100%;
+          max-height: 100%;
+        `}
+        src={svgNode.publicURL}
+        alt={packName}
+        className={className}
+      />
+    );
   }
 
   // In all other cases, render the fallback.
@@ -98,6 +96,7 @@ QuickstartImg.propTypes = {
   packName: PropTypes.string.isRequired,
   className: PropTypes.string,
   imageNode: PropTypes.object,
+  svgNode: PropTypes.object,
 };
 
 export default QuickstartImg;

--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -21,6 +21,7 @@ const QuickstartTile = ({
   title,
   name,
   logo,
+  logoSvg,
   level,
   className,
   summary,
@@ -122,6 +123,7 @@ const QuickstartTile = ({
         >
           <QuickstartImg
             imageNode={logo}
+            svgNode={logoSvg}
             packName={title || name}
             css={css`
               object-fit: scale-down;
@@ -240,6 +242,7 @@ QuickstartTile.propTypes = {
   title: PropTypes.string.isRequired,
   slug: PropTypes.string.isRequired,
   logo: PropTypes.object,
+  logoSvg: PropTypes.object,
   summary: PropTypes.string,
   level: PropTypes.string,
   className: PropTypes.string,

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -779,9 +779,11 @@ export const pageQuery = graphql`
         description
         level
         keywords
-        logo {
+        logoSvg {
           ext
           publicURL
+        }
+        logo {
           childImageSharp {
             gatsbyImageData(
               height: 45

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -242,9 +242,11 @@ export const pageQuery = graphql`
       keywords
       description
       summary
-      logo {
+      logoSvg {
         ext
         publicURL
+      }
+      logo {
         childImageSharp {
           gatsbyImageData(
             height: 45


### PR DESCRIPTION
## Description

This change, while somewhat clunky in the query, prevents the following error from showing up during builds and local development:

```
warn You can't use childImageSharp together with logo.svg — use publicURL instead. The childImageSharp portion of the query in this file will return null:
```

The reason for this error is that sharp does not work with SVG files - they are already performant and do not need any additional optimizations. We needed a separate field so that we could avoid
querying `childImageSharp`.

## Reviewer Notes

I'm curious to hear if folks find this change to be worth it to get rid of these warnings.
