### PR TITLE
Set `Referrer-Policy: no-referrer-when-downgrade` on all pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,7 @@ const quote = (str) => `"${str}"`;
 const resolveQuickstartSlug = require('./src/utils/resolveQuickstartSlug');
 
 module.exports = {
+  pathPrefix: `/instant-observability`,
   trailingSlash: 'never',
   flags: {
     DEV_SSR: true,
@@ -141,7 +142,9 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-gatsby-cloud',
       options: {
-        allPageHeaders: ['Referrer-Policy: no-referrer-when-downgrade'],
+        headers: {
+          '/*': ['Referrer-Policy: no-referrer-when-downgrade'],
+        },
       },
     },
   ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,6 @@ const quote = (str) => `"${str}"`;
 const resolveQuickstartSlug = require('./src/utils/resolveQuickstartSlug');
 
 module.exports = {
-  pathPrefix: `/instant-observability`,
   trailingSlash: 'never',
   flags: {
     DEV_SSR: true,
@@ -143,7 +142,6 @@ module.exports = {
       resolve: 'gatsby-plugin-gatsby-cloud',
       options: {
         allPageHeaders: ['Referrer-Policy: no-referrer-when-downgrade'],
-        mergeCachingHeaders: true,
       },
     },
   ],


### PR DESCRIPTION
The previous settings where creating this header for the `/instant-observability/` page, but we really need it on the `/instant-observability` page. This might be a bug with the `gatsby-plugin-gatsby-cloud` plugin and it's interaction with the `pathPrefix` configuration.