### PR TITLE
Fix quickstart logos cut off

### DIFF
--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -62,12 +62,9 @@ const QuickstartImg = ({ className, packName, imageNode, svgNode }) => {
             display: block;
             max-width: 100%;
             max-height: 100%;
-
-            > img {
-              object-fit: contain;
-            }
           `}
           className={className}
+          imgStyle={{ 'object-fit': 'contain' }}
           image={image}
           alt={packName}
         />

--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -62,9 +62,12 @@ const QuickstartImg = ({ className, packName, imageNode, svgNode }) => {
             display: block;
             max-width: 100%;
             max-height: 100%;
+
+            > img {
+              object-fit: contain;
+            }
           `}
           className={className}
-          imgStyle={{ 'object-fit': 'contain' }}
           image={image}
           alt={packName}
         />

--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -64,6 +64,7 @@ const QuickstartImg = ({ className, packName, imageNode, svgNode }) => {
             max-height: 100%;
           `}
           className={className}
+          imgStyle={{ 'object-fit': 'contain' }}
           image={image}
           alt={packName}
         />


### PR DESCRIPTION
Docs used for solution: https://www.gatsbyjs.com/plugins/gatsby-image/#gatsby-image-props