### PR TITLE
NR-21567: Alignment for quickstart arrow icon on safari

### DIFF
--- a/src/components/QuickstartTile.js
+++ b/src/components/QuickstartTile.js
@@ -229,7 +229,6 @@ const QuickstartTile = ({
             }
           `}
           name="fe-arrow-right"
-          size="120%"
         />
       </div>
     </Surface>


### PR DESCRIPTION
https://issues.newrelic.com/browse/NR-21567
