### PR TITLE
Remove duplicate carousel arrow

### DIFF
--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -105,6 +105,9 @@ input[type='text'] {
   fill: transparent;
 }
 
+.slick-prev:before, .slick-next:before {
+  display: none;
+}
 
 .slick-track {
   display: flex !important;


### PR DESCRIPTION
Now that the site background is not white, the default slick arrows are visible on the page. This code hides them. 

before:
<img width="1218" alt="io-bug" src="https://user-images.githubusercontent.com/47728020/181076436-f6a782cb-478b-459f-a803-4de869d40276.png">

