### PR TITLE
Add padding to search input strings

### DIFF
--- a/src/components/IOBanner.js
+++ b/src/components/IOBanner.js
@@ -85,7 +85,7 @@ const BannerHeaderContent = ({ search, setSearch, handleSearch }) => {
             input {
               height: 64px;
               font-size: 18px;
-              padding: 20px 55px 20px 24px;
+              padding: 20px 78px 20px 24px;
               background: var(--header-background-color);
               border: 1px solid #f9fafa;
               border-radius: 4px;


### PR DESCRIPTION
- long strings would previously overlap with the magnifying glass in the input bar. 
<img width="427" alt="Screen Shot 2022-07-26 at 11 05 26 AM" src="https://user-images.githubusercontent.com/47728020/181079499-d51e8187-e5c2-4dae-9d14-8dd7c80cd069.png">
