### PR TITLE
Dashboard images no longer stretch on safari

### DIFF
--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -88,10 +88,8 @@ const QuickstartDashboards = ({ quickstart }) => {
                         src={node.publicURL}
                         alt={`${dashboard.name} screenshot ${index}`}
                         css={css`
-                          width: 100%;
                           height: 17.5rem;
                           @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                            height: 100%;
                           }
                           border-radius: 4px;
                           padding: 0.25rem;


### PR DESCRIPTION
I looked for this bug in multiple page widths and in Safari, Chrome, and Firefox on a local build + serve. It appears to be gone, while keeping the desired behavior of the images across breakpoints. Please double check. 