### PR TITLE
Dashboard screenshots broken in preview

### DIFF
--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -77,7 +77,7 @@ const QuickstartDashboards = ({ quickstart }) => {
                     `}
                   >
                     <a
-                      href={node}
+                      href={node.publicURL}
                       target="_blank"
                       rel="noreferrer"
                       css={css`
@@ -85,7 +85,7 @@ const QuickstartDashboards = ({ quickstart }) => {
                       `}
                     >
                       <img
-                        src={node}
+                        src={node.publicURL}
                         alt={`${dashboard.name} screenshot ${index}`}
                         css={css`
                           height: 17.5rem;

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -77,7 +77,7 @@ const QuickstartDashboards = ({ quickstart }) => {
                     `}
                   >
                     <a
-                      href={node.publicURL}
+                      href={node}
                       target="_blank"
                       rel="noreferrer"
                       css={css`
@@ -85,7 +85,7 @@ const QuickstartDashboards = ({ quickstart }) => {
                       `}
                     >
                       <img
-                        src={node.publicURL}
+                        src={node}
                         alt={`${dashboard.name} screenshot ${index}`}
                         css={css`
                           height: 17.5rem;

--- a/src/utils/mock_data/content.js
+++ b/src/utils/mock_data/content.js
@@ -135,11 +135,13 @@ export const expectedDashboardOutput = [
   {
     name: 'mock dashboard name',
     description: 'mock dashboard description',
-    screenshots: {
-      publicURL: [
-        'mock/url/for/mock_dashboard01.png',
-        'mock/url/for/mock_dashboard02.png',
-      ],
-    },
+    screenshots: [
+      {
+        publicURL: 'mock/url/for/mock_dashboard01.png',
+      },
+      {
+        publicURL: 'mock/url/for/mock_dashboard02.png',
+      },
+    ],
   },
 ];

--- a/src/utils/mock_data/content.js
+++ b/src/utils/mock_data/content.js
@@ -135,9 +135,11 @@ export const expectedDashboardOutput = [
   {
     name: 'mock dashboard name',
     description: 'mock dashboard description',
-    screenshots: [
-      'mock/url/for/mock_dashboard01.png',
-      'mock/url/for/mock_dashboard02.png',
-    ],
+    screenshots: {
+      publicURL: [
+        'mock/url/for/mock_dashboard01.png',
+        'mock/url/for/mock_dashboard02.png',
+      ],
+    },
   },
 ];

--- a/src/utils/mock_data/content.js
+++ b/src/utils/mock_data/content.js
@@ -135,13 +135,11 @@ export const expectedDashboardOutput = [
   {
     name: 'mock dashboard name',
     description: 'mock dashboard description',
-    screenshots: [
-      {
-        publicURL: 'mock/url/for/mock_dashboard01.png',
-      },
-      {
-        publicURL: 'mock/url/for/mock_dashboard02.png',
-      },
-    ],
+    screenshots: {
+      publicURL: [
+        'mock/url/for/mock_dashboard01.png',
+        'mock/url/for/mock_dashboard02.png',
+      ],
+    },
   },
 ];

--- a/src/utils/preview/parseHelpers.js
+++ b/src/utils/preview/parseHelpers.js
@@ -105,7 +105,7 @@ export const parseDashboardFiles = (files) => {
       description: dashboard?.description ?? 'Placeholder description',
       screenshots: screenshots
         .filter((s) => s.filePath.includes(parentDir))
-        .map(({ content }) => content),
+        .map(({ content }) => ({ publicURL: content })),
     };
   });
 };


### PR DESCRIPTION
Previously the IMG element was not receiving a src:
`<img alt="Dotnet screenshot 0" class="css-axom38-QuickstartDashboards">`

I am realizing that the issue is that the quickstarts for the regular page and the previews are sending different shapes to the QuickstartDashboard component.

the previews are using fs to just sending an array of screenshot urls in the repo :

``` javascript
0: "http://localhost:3000/dashboards/dotnet/dotnet.png" 
1: "http://localhost:3000/dashboards/dotnet/dotnet02.png" 
2: "http://localhost:3000/dashboards/dotnet/dotnet03.png"
```
while the regular page is getting a graphql response that has nested the screenshot URLs after we added sharp

``` graphql
screenshots {
        publicURL
} 
```