### PR TITLE
More image improvements

### DIFF
--- a/src/components/LandingBanner/index.js
+++ b/src/components/LandingBanner/index.js
@@ -9,11 +9,12 @@ import { quickstart } from '../../types';
 import QuickstartImg from '../QuickstartImg';
 import defaultImage from '../../images/defaultQuickstartImage.png';
 import BannerBackground from './BannerBackground';
+import SafeImage from '../SafeImage';
 
 const IMAGE_DISPLAY_BREAKPOINT = '1248px';
 
 const LandingBanner = ({ quickstart, className, location }) => {
-  const bannerImg = useDetermineBannerImg(quickstart, defaultImage);
+  const bannerImg = determineBannerImg(quickstart, defaultImage);
 
   const breadcrumbs = [
     {
@@ -158,13 +159,16 @@ const LandingBanner = ({ quickstart, className, location }) => {
             }
           `}
         >
-          <img
+          <SafeImage
             src={bannerImg}
+            imageNode={bannerImg}
+            rawNode={bannerImg}
             alt={quickstart.title}
             css={css`
               border: 28px solid #000000;
               border-radius: 26px;
               height: 250px;
+              max-width: unset;
               background: white;
             `}
           />
@@ -186,45 +190,25 @@ const LandingBanner = ({ quickstart, className, location }) => {
   );
 };
 
-function useDetermineBannerImg(quickstart, defaultImage) {
-  const [bannerImg, setBannerImg] = useState(defaultImage);
+const determineBannerImg = (quickstart, defaultImage) => {
+  let image = { publicURL: defaultImage };
 
-  // get image resolution from URL
-  const getURLMeta = async (url) => {
-    const img = new Image();
-    img.src = url;
-    const { width, height } = await new Promise((resolve) => {
-      img.onload = function () {
-        resolve({
-          width: this.width,
-          height: this.height,
-        });
-      };
-    });
-    return { width, height };
-  };
-
-  const checkImgAspectRatio = async () => {
-    let image = bannerImg;
-
-    for (const screenshot of quickstart.dashboards[0]?.screenshots ?? []) {
-      const { width, height } = await getURLMeta(screenshot);
-      const aspectRatio = width / height;
-      if (aspectRatio > 1.6 && aspectRatio < 2.2) {
-        // set image to this screenshot if its the ideal aspect ratio  of ~1.9
-        image = screenshot;
-        break;
-      }
+  for (const screenshot of quickstart.dashboards[0]?.screenshots ?? []) {
+    if (!quickstart.bannerImg) {
+      continue;
     }
-    setBannerImg(image);
-  };
 
-  useEffect(() => {
-    checkImgAspectRatio();
-  });
+    const { width, height } = screenshot.bannerImg?.gatsbyImageData;
+    const aspectRatio = width / height;
 
-  return bannerImg;
-}
+    if (aspectRatio > 1.6 && aspectRatio < 2.2) {
+      image = screenshot;
+      break;
+    }
+  }
+
+  return image;
+};
 
 LandingBanner.propTypes = {
   quickstart: quickstart.isRequired,
@@ -244,6 +228,19 @@ export const fragmentQuery = graphql`
     logo {
       childImageSharp {
         gatsbyImageData(height: 45, placeholder: BLURRED, formats: [AUTO, WEBP])
+      }
+    }
+    dashboards {
+      screenshots {
+        publicURL
+        bannerImg: childImageSharp {
+          gatsbyImageData(
+            placeholder: BLURRED
+            layout: FIXED
+            formats: [AUTO, WEBP]
+            height: 250
+          )
+        }
       }
     }
   }

--- a/src/components/LandingBanner/index.js
+++ b/src/components/LandingBanner/index.js
@@ -17,7 +17,6 @@ const LandingBanner = ({ quickstart, className, location }) => {
   const bannerImg = useDetermineBannerImg(quickstart, {
     publicURL: defaultImage,
   });
-  //const bannerImg = determineBannerImg(quickstart, defaultImage);
 
   const breadcrumbs = [
     {

--- a/src/components/LandingBanner/index.js
+++ b/src/components/LandingBanner/index.js
@@ -221,13 +221,12 @@ function useDetermineBannerImg(quickstart, defaultImage) {
 
     for (const screenshot of quickstart.dashboards[0]?.screenshots ?? []) {
       const { width, height } =
-        screenshot.bannerImg?.gatsbyImageData ??
-        (await getURLMeta(screenshot.publicURL));
+        screenshot.gatsbyImageData ?? (await getURLMeta(screenshot.publicURL));
 
       const aspectRatio = width / height;
       if (aspectRatio > 1.6 && aspectRatio < 2.2) {
         // set image to this screenshot if its the ideal aspect ratio  of ~1.9
-        image = screenshot?.bannerImg ?? screenshot;
+        image = screenshot;
         break;
       }
     }
@@ -264,12 +263,12 @@ export const fragmentQuery = graphql`
     dashboards {
       screenshots {
         publicURL
-        bannerImg: childImageSharp {
+        childImageSharp {
           gatsbyImageData(
             placeholder: BLURRED
-            layout: FIXED
+            layout: CONSTRAINED
             formats: [AUTO, WEBP]
-            height: 250
+            height: 272
           )
         }
       }

--- a/src/components/LandingBanner/index.js
+++ b/src/components/LandingBanner/index.js
@@ -205,7 +205,7 @@ function useDetermineBannerImg(quickstart, defaultImage) {
   const getURLMeta = async (url) => {
     const img = new Image();
     img.src = url;
-    const { width, height } = await new Promise((resolve) => {
+    const { width = 0, height = 0 } = await new Promise((resolve) => {
       img.onload = function () {
         resolve({
           width: this.width,
@@ -258,19 +258,6 @@ export const fragmentQuery = graphql`
     logo {
       childImageSharp {
         gatsbyImageData(height: 45, placeholder: BLURRED, formats: [AUTO, WEBP])
-      }
-    }
-    dashboards {
-      screenshots {
-        publicURL
-        childImageSharp {
-          gatsbyImageData(
-            placeholder: BLURRED
-            layout: CONSTRAINED
-            formats: [AUTO, WEBP]
-            height: 272
-          )
-        }
       }
     }
   }

--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -24,7 +24,7 @@ const Overlay = ({ children, onCloseOverlay, isOpen = false, className }) => {
         onCloseOverlay();
       }
     },
-    [ref.current, onCloseOverlay]
+    [onCloseOverlay]
   );
 
   useEffect(() => {

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -89,6 +89,7 @@ const QuickstartDashboards = ({ quickstart }) => {
                       <SafeImage
                         css={css`
                           padding: 0.25rem;
+                          height: 272px;
                         `}
                         imageNode={node}
                         rawNode={node}

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { graphql } from 'gatsby';
 import Slider from 'react-slick';
 import { animated } from 'react-spring';

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { css } from '@emotion/react';
-import pluralize from 'pluralize';
-import Intro from './Intro';
-import { quickstart } from '../types';
-import Slider from 'react-slick';
-import { graphql } from 'gatsby';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
+import { graphql } from 'gatsby';
+import Slider from 'react-slick';
 import { animated } from 'react-spring';
+import pluralize from 'pluralize';
+
+import { css } from '@emotion/react';
+import { quickstart } from '../types';
+import Intro from './Intro';
+import SafeImage from './SafeImage';
 
 import { dashboardSettings } from '../data/slick-settings';
 
@@ -84,13 +86,12 @@ const QuickstartDashboards = ({ quickstart }) => {
                         margin: auto;
                       `}
                     >
-                      <GatsbyImage
+                      <SafeImage
                         css={css`
                           padding: 0.25rem;
                         `}
-                        imgStyle={{ borderRadius: '4px' }}
-                        objectFit="contain"
-                        image={getImage(node)}
+                        imageNode={node}
+                        rawNode={node}
                         alt={`${dashboard.name} screenshot ${index}`}
                       />
                     </a>

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -5,6 +5,7 @@ import Intro from './Intro';
 import { quickstart } from '../types';
 import Slider from 'react-slick';
 import { graphql } from 'gatsby';
+import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { animated } from 'react-spring';
 
 import { dashboardSettings } from '../data/slick-settings';
@@ -84,16 +85,14 @@ const QuickstartDashboards = ({ quickstart }) => {
                         margin: auto;
                       `}
                     >
-                      <img
-                        src={node.publicURL}
-                        alt={`${dashboard.name} screenshot ${index}`}
+                      <GatsbyImage
                         css={css`
-                          height: 17.5rem;
-                          @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                          }
-                          border-radius: 4px;
                           padding: 0.25rem;
                         `}
+                        imgStyle={{ borderRadius: '4px' }}
+                        objectFit="contain"
+                        image={getImage(node)}
+                        alt={`${dashboard.name} screenshot ${index}`}
                       />
                     </a>
                   </animated.div>
@@ -119,7 +118,12 @@ export const fragmentQuery = graphql`
       screenshots {
         publicURL
         childImageSharp {
-          gatsbyImageData(placeholder: BLURRED, formats: [AUTO, WEBP])
+          gatsbyImageData(
+            placeholder: BLURRED
+            layout: CONSTRAINED
+            formats: [AUTO, WEBP]
+            height: 272
+          )
         }
       }
     }

--- a/src/components/QuickstartDashboards.js
+++ b/src/components/QuickstartDashboards.js
@@ -9,7 +9,6 @@ import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { animated } from 'react-spring';
 
 import { dashboardSettings } from '../data/slick-settings';
-import { MOBILE_BREAKPOINT } from '../data/constants';
 
 const QuickstartDashboards = ({ quickstart }) => {
   const renderDescription = (dashboard) => {

--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -85,6 +85,7 @@ const QuickstartImg = ({ className, packName, imageNode, svgNode }) => {
         src={svgNode.publicURL}
         alt={packName}
         className={className}
+        loading="lazy"
       />
     );
   }

--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import DEFAULT_IMAGE from '../images/default-logo-background.svg';
+import SafeImage from '@components/SafeImage';
 
 /**
  * Given a quickstart name, this will return the acronym.
@@ -51,41 +52,13 @@ FallbackImg.propTypes = {
 };
 
 const QuickstartImg = ({ className, packName, imageNode, svgNode }) => {
-  if (imageNode) {
-    // If we have an image for sharp to optimize, use GatsbyImage
-    const image = getImage(imageNode);
-
-    if (image) {
-      return (
-        <GatsbyImage
-          css={css`
-            display: block;
-            max-width: 100%;
-            max-height: 100%;
-          `}
-          className={className}
-          imgStyle={{ 'object-fit': 'contain' }}
-          image={image}
-          alt={packName}
-        />
-      );
-    }
-  }
-
-  // If we don't have a sharp-capable image, but we have a URL, it's an
-  // SVG (already performant) and is already built with the site.
-  if (svgNode) {
+  if (imageNode || svgNode) {
     return (
-      <img
-        css={css`
-          display: block;
-          max-width: 100%;
-          max-height: 100%;
-        `}
-        src={svgNode.publicURL}
+      <SafeImage
         alt={packName}
+        imageNode={imageNode}
+        rawNode={svgNode}
         className={className}
-        loading="lazy"
       />
     );
   }

--- a/src/components/QuickstartImg.js
+++ b/src/components/QuickstartImg.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import DEFAULT_IMAGE from '../images/default-logo-background.svg';
 import SafeImage from '@components/SafeImage';
 

--- a/src/components/SafeImage.js
+++ b/src/components/SafeImage.js
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types';
 
 /**
  * Renders a `GatsbyImage` with an optional fallback to `img`
- * @param {Object} imageNode - a `childImageSharp` image node
- * @param {Object} rawNode - a raw image node, this will be used if `imageNode` is undefined
- * @param {String} alt - the alt tag for the image
- * @param {String} className - used to pass around `@emotion` css classes
+ * @param {Object} props
+ * @param {Object} props.imageNode - a `childImageSharp` image node
+ * @param {Object} props.rawNode - a raw image node, this will be used if `imageNode` is undefined
+ * @param {String} props.alt - the alt tag for the image
+ * @param {String} props.className - used to pass around `@emotion` css classes
  */
 const SafeImage = ({ className, alt, imageNode, rawNode }) => {
   if (imageNode) {

--- a/src/components/SafeImage.js
+++ b/src/components/SafeImage.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { GatsbyImage, getImage } from 'gatsby-plugin-image';
+import { css } from '@emotion/react';
+import PropTypes from 'prop-types';
+
+const SafeImage = ({ className, alt, imageNode, rawNode }) => {
+  if (imageNode) {
+    // If we have an image for sharp to optimize, use GatsbyImage
+    const image = getImage(imageNode);
+
+    if (image) {
+      return (
+        <GatsbyImage
+          css={css`
+            display: block;
+            max-width: 100%;
+            max-height: 100%;
+          `}
+          className={className}
+          objectFit="contain"
+          image={image}
+          alt={alt}
+        />
+      );
+    }
+  }
+
+  // If we don't have a sharp-capable image, but we have a URL, it's an
+  // SVG (already performant) and is already built with the site.
+  return (
+    <img
+      css={css`
+        display: block;
+        max-width: 100%;
+        max-height: 100%;
+      `}
+      src={rawNode.publicURL}
+      alt={alt}
+      className={className}
+      loading="lazy"
+    />
+  );
+};
+
+SafeImage.propTypes = {
+  alt: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  imageNode: PropTypes.object,
+  rawNode: PropTypes.shape({ publicURL: PropTypes.string.isRequired }),
+};
+
+export default SafeImage;

--- a/src/components/SafeImage.js
+++ b/src/components/SafeImage.js
@@ -3,6 +3,13 @@ import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 
+/**
+ * Renders a `GatsbyImage` with an optional fallback to `img`
+ * @param {Object} imageNode - a `childImageSharp` image node
+ * @param {Object} rawNode - a raw image node, this will be used if `imageNode` is undefined
+ * @param {String} alt - the alt tag for the image
+ * @param {String} className - used to pass around `@emotion` css classes
+ */
 const SafeImage = ({ className, alt, imageNode, rawNode }) => {
   if (imageNode) {
     // If we have an image for sharp to optimize, use GatsbyImage

--- a/src/hooks/useQuickstartPreview.js
+++ b/src/hooks/useQuickstartPreview.js
@@ -64,7 +64,7 @@ const useQuickstartPreview = (prNumber, quickstartPath, isLocal, port) => {
     };
 
     fetchFiles();
-  }, []);
+  }, [isLocal, port, prNumber, quickstartPath, tessen]);
 
   return quickstart;
 };


### PR DESCRIPTION
# Summary
I noticed that we were still getting dinged for the images we load "below the fold". As I dug into that I noticed that all of the SVGs in the catalogue were being loaded "eagerly" and that the landing pages were not using the version of the image processed by sharp during build.

This PR does the following:
* Implements a generic `SafeImage` component that uses `GatsbyImage` and falls back to `img` if needed
* Lazy load all SVGs
* Update `QuickstartImg` to use the new image component
* Update dashboard screenshots carousel to use the new image component
* Update landing banner image to use the new image component
* Various linting fixes
