### PR TITLE
NR-35139: Add ability to set custom meta titles and descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,21 @@ Before submitting an Issue, please search for similar ones in the
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
 3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
+## Adding custom meta tags
+
+Custom meta tags can be added for a quickstart in [quickstart-metadata.json](src/data/quickstart-metadata.json)
+You will need to add an object to the array within this file in the following format:
+
+```
+{
+  "slug": <slug of quickstart>,
+  "title": <title which should be in title meta tag>,
+  "description": <description which should be in description meta tag>
+}
+```
+
+Create a pull request following the above guidelines with this change and we will get it merged as soon as possible.
+
 ## Contributor License Agreement
 
 Keep in mind that when you submit your Pull Request, you'll need to sign the CLA via the click-through using CLA-Assistant. If you'd like to execute our corporate CLA, or if you have any questions, please drop us an email at opensource@newrelic.com.
@@ -27,4 +42,4 @@ For more information about CLAs, please check out Alex Russell’s excellent pos
 
 ## Slack
 
-We host a public Slack with a dedicated channel for contributors and maintainers of open source projects hosted by New Relic.  If you are contributing to this project, you're welcome to request access to the #oss-contributors channel in the newrelicusers.slack.com workspace.  To request access, see https://newrelicusers-signup.herokuapp.com/.
+We host a public Slack with a dedicated channel for contributors and maintainers of open source projects hosted by New Relic. If you are contributing to this project, you're welcome to request access to the #oss-contributors channel in the newrelicusers.slack.com workspace. To request access, see https://newrelicusers-signup.herokuapp.com/.

--- a/src/components/IOSeo.js
+++ b/src/components/IOSeo.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Seo from '@newrelic/gatsby-theme-newrelic/src/components/SEO';
 import { useStaticQuery, graphql } from 'gatsby';
+import quickstartMetadata from '@data/quickstart-metadata';
 
-function IOSeo({ description, meta, title, tags, location, type }) {
+function IOSeo({ description, meta, title, tags, location, type, summary }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -38,8 +39,17 @@ function IOSeo({ description, meta, title, tags, location, type }) {
         />
       );
   };
-
-  const metaDescription = description || site.siteMetadata.description;
+  const slug = location.pathname.split('/')[1];
+  const customMetadata = quickstartMetadata.find((x) => x.slug === slug);
+  const isHomeRoute = location.pathname === '/';
+  const quickstartMetaDescription = customMetadata
+    ? customMetadata.description
+    : summary;
+  const metaDescription = isHomeRoute
+    ? site.siteMetadata.description
+    : quickstartMetaDescription;
+  const metaTitle =
+    isHomeRoute || !customMetadata ? title : customMetadata.title;
 
   const globalMetadata = [
     { name: 'description', content: metaDescription },
@@ -52,12 +62,12 @@ function IOSeo({ description, meta, title, tags, location, type }) {
   ];
 
   const social = [
-    { property: 'og:title', content: title },
+    { property: 'og:title', content: metaTitle },
     { property: 'og:description', content: metaDescription },
     { property: 'og:type', content: 'website' },
     { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:creator', content: site.siteMetadata.author },
-    { name: 'twitter:title', content: title },
+    { name: 'twitter:title', content: metaTitle },
     { name: 'twitter:description', content: metaDescription },
   ];
 
@@ -120,6 +130,7 @@ IOSeo.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.string),
   type: PropTypes.string,
   quickStartName: PropTypes.string,
+  summary: PropTypes.string,
 };
 
 export default IOSeo;

--- a/src/data/quickstart-metadata.json
+++ b/src/data/quickstart-metadata.json
@@ -1,0 +1,7 @@
+[
+  {
+    "slug": "example",
+    "title": "meta title",
+    "description": "meta description"
+  }
+]

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -63,6 +63,7 @@ const QuickstartDetails = ({ data, location }) => {
         location={location}
         tags={quickstart.keywords}
         meta={quickStartMeta}
+        summary={quickstart.summary}
       />
       <PageLayout.Header
         css={css`


### PR DESCRIPTION
https://issues.newrelic.com/browse/NR-35139

The `description` prop in IOSeo.js doesn't seem to ever be used.  Can we remove it?

I'm counting on slug being the first part of the url which seems to work, but let me know if there are any cases where this isn't true.