### PR TITLE
NR-35139: Add ability to set custom meta titles and descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,21 +18,6 @@ Before submitting an Issue, please search for similar ones in the
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
 3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
-## Adding custom meta tags
-
-Custom meta tags can be added for a quickstart in [quickstart-metadata.json](src/data/quickstart-metadata.json)
-You will need to add an object to the array within this file in the following format:
-
-```
-{
-  "slug": <slug of quickstart>,
-  "title": <title which should be in title meta tag>,
-  "description": <description which should be in description meta tag>
-}
-```
-
-Create a pull request following the above guidelines with this change and we will get it merged as soon as possible.
-
 ## Contributor License Agreement
 
 Keep in mind that when you submit your Pull Request, you'll need to sign the CLA via the click-through using CLA-Assistant. If you'd like to execute our corporate CLA, or if you have any questions, please drop us an email at opensource@newrelic.com.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,21 @@ Before submitting an Issue, please search for similar ones in the
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
 3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
+## Adding custom meta tags
+
+Custom meta tags can be added for a quickstart in [quickstart-metadata.json](src/data/quickstart-metadata.json)
+You will need to add an object to the array within this file in the following format:
+
+```
+{
+  "slug": <slug of quickstart>,
+  "title": <title which should be in title meta tag>,
+  "description": <description which should be in description meta tag>
+}
+```
+
+Create a pull request following the above guidelines with this change and we will get it merged as soon as possible.
+
 ## Contributor License Agreement
 
 Keep in mind that when you submit your Pull Request, you'll need to sign the CLA via the click-through using CLA-Assistant. If you'd like to execute our corporate CLA, or if you have any questions, please drop us an email at opensource@newrelic.com.
@@ -27,4 +42,4 @@ For more information about CLAs, please check out Alex Russell’s excellent pos
 
 ## Slack
 
-We host a public Slack with a dedicated channel for contributors and maintainers of open source projects hosted by New Relic.  If you are contributing to this project, you're welcome to request access to the #oss-contributors channel in the newrelicusers.slack.com workspace.  To request access, see https://newrelicusers-signup.herokuapp.com/.
+We host a public Slack with a dedicated channel for contributors and maintainers of open source projects hosted by New Relic. If you are contributing to this project, you're welcome to request access to the #oss-contributors channel in the newrelicusers.slack.com workspace. To request access, see https://newrelicusers-signup.herokuapp.com/.

--- a/README.md
+++ b/README.md
@@ -95,14 +95,23 @@ To add a new set of meta tags for a quickstart, add the following to the quickst
 
 ```
 {
-  "slug": {
+  "<quickstart slug>": {
     "title": <title which should be in title meta tag>,
     "description": <description which should be in description meta tag>
   }
 }
 ```
 
-Create a pull request following the guidelines from [CONTRIBUTING.md](CONTRIBUTING.md)
+For example, to add a custom meta title and description to a quickstart with the slug cool-qs:
+
+```
+{
+  "cool-qs": {
+    "title": "Cool QS",
+    "description": "Cool qs description for SEO purposes"
+  }
+}
+```
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This can also be kicked off manually via a workflow run.
 ## Adding custom meta tags
 
 Custom meta tags can be added for a quickstart in [quickstart-metadata.json](src/data/quickstart-metadata.json)
-You will need to add a key to the object within this file in the following format:
+To add a new set of meta tags for a quickstart, add the following to the quickstart-metadata.json file.
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -91,13 +91,14 @@ This can also be kicked off manually via a workflow run.
 ## Adding custom meta tags
 
 Custom meta tags can be added for a quickstart in [quickstart-metadata.json](src/data/quickstart-metadata.json)
-You will need to add an object to the array within this file in the following format:
+You will need to add a key to the object within this file in the following format:
 
 ```
 {
-  "slug": <slug of quickstart>,
-  "title": <title which should be in title meta tag>,
-  "description": <description which should be in description meta tag>
+  "slug": {
+    "title": <title which should be in title meta tag>,
+    "description": <description which should be in description meta tag>
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 [![Community Project header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Community_Project.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#category-community-project)
 
-
 # Instant Observability Website
 
 _Dashboards, alerts, and integrations all in one place._
 This site hosts the public version of the Instant Observability Marketplace
+
+- [Dependencies](#dependencies)
+- [Production build](#production-build)
+- [Path prefix](#path-prefix)
+- [CI/CD](#cicd)
+- [Adding custom meta tags](#adding-custom-meta-tags)
+- [Support](#support)
+- [Contributing](#contributing)
+- [Code of conduct](#code-of-conduct)
+- [Issues / enhancement requests](#issues-enhancement-requests)
+- [License](#license)
+- [Security](#security)
 
 ## Dependencies
 
@@ -72,17 +83,32 @@ Runs every day to get various pages that relate to each quickstart from our vend
 Runs on every push to the `main` branch and clears out the `newrelic.com/instant-observability` cache.
 This can also be kicked off manually via a workflow run.
 
-## ☁️  Hosting
+## ☁️ Hosting
 
 - This site is built and hosted on [Gatsby Cloud](https://www.gatsbyjs.com/products/cloud/)
 - Changes are published on pushes to `main`.
 
+## Adding custom meta tags
+
+Custom meta tags can be added for a quickstart in [quickstart-metadata.json](src/data/quickstart-metadata.json)
+You will need to add an object to the array within this file in the following format:
+
+```
+{
+  "slug": <slug of quickstart>,
+  "title": <title which should be in title meta tag>,
+  "description": <description which should be in description meta tag>
+}
+```
+
+Create a pull request following the guidelines from [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ### Environment variables
 
-|key|possible values|notes|
-|-|-|-|
-|`GATSBY_NEWRELIC_ENV`|`development` or `production`| Used by the [New Relic Gatsby Theme](https://github.com/newrelic/gatsby-theme-newrelic) to determine the running environment. Set to `production` on prod.|
-|`PREFIX_PATHS`|`true` or `false`|Enables path prefixing during builds and deployments. Set to `true` on prod.|
+| key                   | possible values               | notes                                                                                                                                                      |
+| --------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GATSBY_NEWRELIC_ENV` | `development` or `production` | Used by the [New Relic Gatsby Theme](https://github.com/newrelic/gatsby-theme-newrelic) to determine the running environment. Set to `production` on prod. |
+| `PREFIX_PATHS`        | `true` or `false`             | Enables path prefixing during builds and deployments. Set to `true` on prod.                                                                               |
 
 ## 🩹 Support
 
@@ -110,7 +136,8 @@ issue to prevent the submission of duplicate issues.
 ## 🖋 License
 
 The Instant Observability Website is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
->The Instant Observability Website also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document
+
+> The Instant Observability Website also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document
 
 ## 🔒 Security
 

--- a/src/components/IOSeo.js
+++ b/src/components/IOSeo.js
@@ -4,7 +4,7 @@ import Seo from '@newrelic/gatsby-theme-newrelic/src/components/SEO';
 import { useStaticQuery, graphql } from 'gatsby';
 import quickstartMetadata from '@data/quickstart-metadata';
 
-function IOSeo({ description, meta, title, tags, location, type, summary }) {
+function IOSeo({ meta, title, tags, location, type, summary }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -39,8 +39,9 @@ function IOSeo({ description, meta, title, tags, location, type, summary }) {
         />
       );
   };
+
   const slug = location.pathname.split('/')[1];
-  const customMetadata = quickstartMetadata.find((x) => x.slug === slug);
+  const customMetadata = quickstartMetadata[slug];
   const isHomeRoute = location.pathname === '/';
   const quickstartMetaDescription = customMetadata
     ? customMetadata.description
@@ -89,7 +90,7 @@ function IOSeo({ description, meta, title, tags, location, type, summary }) {
       name: 'info',
       class: 'swiftype',
       'data-type': 'string',
-      content: description,
+      content: metaDescription,
     },
     ...(tags ?? []).map((tag) => ({
       name: 'tags',
@@ -124,7 +125,6 @@ IOSeo.defaultProps = {
 
 IOSeo.propTypes = {
   location: PropTypes.object.isRequired,
-  description: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string,
   tags: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/IOSeo.js
+++ b/src/components/IOSeo.js
@@ -120,7 +120,6 @@ function IOSeo({ meta, title, tags, location, type, summary }) {
 
 IOSeo.defaultProps = {
   meta: [],
-  description: '',
 };
 
 IOSeo.propTypes = {

--- a/src/components/IOSeo.js
+++ b/src/components/IOSeo.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Seo from '@newrelic/gatsby-theme-newrelic/src/components/SEO';
 import { useStaticQuery, graphql } from 'gatsby';
+import quickstartMetadata from '@data/quickstart-metadata';
 
-function IOSeo({ description, meta, title, tags, location, type }) {
+function IOSeo({ description, meta, title, tags, location, type, summary }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -38,8 +39,17 @@ function IOSeo({ description, meta, title, tags, location, type }) {
         />
       );
   };
-
-  const metaDescription = description || site.siteMetadata.description;
+  const slug = location.pathname.split('/')[1];
+  const customMetadata = quickstartMetadata.find((x) => x.slug === slug);
+  const isHomeRoute = location.pathname === '/';
+  const quickstartMetaDescription = customMetadata
+    ? customMetadata.description
+    : summary;
+  const metaDescription = isHomeRoute
+    ? site.siteMetadata.description
+    : quickstartMetaDescription;
+  const metaTitle =
+    isHomeRoute || !customMetadata ? title : customMetadata.title;
 
   const globalMetadata = [
     { name: 'description', content: metaDescription },
@@ -52,12 +62,12 @@ function IOSeo({ description, meta, title, tags, location, type }) {
   ];
 
   const social = [
-    { property: 'og:title', content: title },
+    { property: 'og:title', content: metaTitle },
     { property: 'og:description', content: metaDescription },
     { property: 'og:type', content: 'website' },
     { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:creator', content: site.siteMetadata.author },
-    { name: 'twitter:title', content: title },
+    { name: 'twitter:title', content: metaTitle },
     { name: 'twitter:description', content: metaDescription },
   ];
 
@@ -120,6 +130,7 @@ IOSeo.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.string),
   type: PropTypes.string,
   quickStartName: PropTypes.string,
+  summary: PropTypes.string,
 };
 
 export default IOSeo;

--- a/src/components/IOSeo.js
+++ b/src/components/IOSeo.js
@@ -2,9 +2,57 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Seo from '@newrelic/gatsby-theme-newrelic/src/components/SEO';
 import { useStaticQuery, graphql } from 'gatsby';
-import quickstartMetadata from '@data/quickstart-metadata';
+import quickstartsMetadata from '@data/quickstart-metadata';
 
-function IOSeo({ meta, title, tags, location, type, summary }) {
+/**
+ * @param {string} siteMetadataDescription
+ * @param {string} [summary]
+ * @param {Object} [quickstartMetadata]
+ * @param {string} [quickstartMetadata.description]
+ * @returns {string}
+ */
+const getMetaDescription = (
+  siteMetadataDescription,
+  summary,
+  quickstartMetadata
+) => {
+  // if we have a quickstart-specific description
+  if (quickstartMetadata && quickstartMetadata.description) {
+    return quickstartMetadata.description;
+  }
+
+  // if we have a summary
+  if (summary) {
+    return summary;
+  }
+
+  // default to site metadata description
+  return siteMetadataDescription;
+};
+
+/**
+ * @param {string} siteMetadataTitle
+ * @param {string} [title]
+ * @param {Object} [quickstartMetadata]
+ * @param {string} [quickstartMetadata.title]
+ * @returns {string}
+ */
+const getMetaTitle = (siteMetadataTitle, title, quickstartMetadata) => {
+  // if we have custom metadata defined (with a title)
+  if (quickstartMetadata && quickstartMetadata.title) {
+    return quickstartMetadata.title;
+  }
+
+  // If we have a title prop
+  if (title) {
+    return title;
+  }
+
+  // default to site metadata title
+  return siteMetadataTitle;
+};
+
+function IOSeo({ meta, name, title, tags, location, type, summary }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -40,17 +88,20 @@ function IOSeo({ meta, title, tags, location, type, summary }) {
       );
   };
 
-  const slug = location.pathname.split('/')[1];
-  const customMetadata = quickstartMetadata[slug];
-  const isHomeRoute = location.pathname === '/';
-  const quickstartMetaDescription = customMetadata
-    ? customMetadata.description
-    : summary;
-  const metaDescription = isHomeRoute
-    ? site.siteMetadata.description
-    : quickstartMetaDescription;
-  const metaTitle =
-    isHomeRoute || !customMetadata ? title : customMetadata.title;
+  const {
+    description: siteMetadataDescription,
+    title: siteMetadataTitle,
+  } = site.siteMetadata;
+
+  const quickstartMetadata = quickstartsMetadata[name];
+
+  const metaDescription = getMetaDescription(
+    siteMetadataDescription,
+    summary,
+    quickstartMetadata
+  );
+
+  const metaTitle = getMetaTitle(siteMetadataTitle, title, quickstartMetadata);
 
   const globalMetadata = [
     { name: 'description', content: metaDescription },
@@ -130,6 +181,13 @@ IOSeo.propTypes = {
   type: PropTypes.string,
   quickStartName: PropTypes.string,
   summary: PropTypes.string,
+  /**
+   * The `slug` field in the quickstart configuration and the NerdGraph
+   * API.
+   *
+   * @note that this is considered `name` in the Gatsby GraphQL.
+   */
+  name: PropTypes.string,
 };
 
 export default IOSeo;

--- a/src/data/quickstart-metadata.json
+++ b/src/data/quickstart-metadata.json
@@ -1,6 +1,2 @@
 {
-  "slug": {
-    "title": "meta title",
-    "description": "meta description"
-  }
 }

--- a/src/data/quickstart-metadata.json
+++ b/src/data/quickstart-metadata.json
@@ -1,0 +1,7 @@
+[
+  {
+    "slug": "example",
+    "title": "meta title",
+    "description": "meta description"
+  }
+]

--- a/src/data/quickstart-metadata.json
+++ b/src/data/quickstart-metadata.json
@@ -1,7 +1,6 @@
-[
-  {
-    "slug": "example",
+{
+  "slug": {
     "title": "meta title",
     "description": "meta description"
   }
-]
+}

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -63,6 +63,7 @@ const QuickstartDetails = ({ data, location }) => {
         location={location}
         tags={quickstart.keywords}
         meta={quickStartMeta}
+        summary={quickstart.summary}
       />
       <PageLayout.Header
         css={css`

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -59,6 +59,7 @@ const QuickstartDetails = ({ data, location }) => {
     <>
       <IOSeo
         title={quickstart.title}
+        name={quickstart.name}
         type="quickstarts"
         location={location}
         tags={quickstart.keywords}


### PR DESCRIPTION
https://issues.newrelic.com/browse/NR-35139

The `description` prop doesn't seem to be used in `IOSeo.js`.  Can we remove it?

I am depending on the slug being the first part of the url which appears to work.  Please let me know if theres a case where this isn't true.

I did some reading on character limits for meta title/descriptions. It seems the limit for title is ~70 and description ~160. However these are apparently automatically truncated if they are too long, so I did not do any manual truncating of the strings and wanted to leave this open for discussion.