### PR TITLE
Re-reduce bundle size

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,5 +66,20 @@ module.exports = {
         ignoreRestSiblings: false,
       },
     ],
+    // This prevents us from accidently importing from the theme's `index` file
+    // and pulling in a bunch of extra dependecies.
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@newrelic/gatsby-theme-newrelic',
+            message:
+              'Please import the module directly from @newrelic/gatsby-theme-newrelic/src/[module] instead.',
+          },
+        ],
+        patterns: ['!@newrelic/gatsby-theme-newrelic/*'],
+      },
+    ],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = {
       },
     ],
     // This prevents us from accidently importing from the theme's `index` file
-    // and pulling in a bunch of extra dependecies.
+    // and pulling in a bunch of extra dependencies.
     'no-restricted-imports': [
       'error',
       {

--- a/src/components/GoToTopButton.js
+++ b/src/components/GoToTopButton.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
-import { Button } from '@newrelic/gatsby-theme-newrelic';
+import Button from '@newrelic/gatsby-theme-newrelic/src/components/Button';
 
 import featherIcons from '@newrelic/gatsby-theme-newrelic/src/icons/feather';
 

--- a/src/components/QuickstartGrid.js
+++ b/src/components/QuickstartGrid.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { Button, Surface } from '@newrelic/gatsby-theme-newrelic';
+import Button from '@newrelic/gatsby-theme-newrelic/src/components/Button';
+import Surface from '@newrelic/gatsby-theme-newrelic/src/components/Surface';
 import QuickstartTile from '@components/QuickstartTile';
 import { quickstart } from '../types';
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -22,7 +22,7 @@ import allFilteredQuickstarts from '@utils/allFilteredQuickstarts';
 import getDisplayName from '@utils/getDisplayName';
 // Components
 import Slider from 'react-slick';
-import { Spinner } from '@newrelic/gatsby-theme-newrelic';
+import Spinner from '@newrelic/gatsby-theme-newrelic/src/components/Spinner';
 import IOBanner from '@components/IOBanner';
 import IOSeo from '@components/IOSeo';
 import QuickstartTile from '@components/QuickstartTile';


### PR DESCRIPTION
* We missed some imports from the default theme exporter file during PR
  review
* This lead to our bundle size being increase back to what it was before
  we worked on it
* This corrects those imports and adds an eslint rule to help us avoid
  this issue in the future
* Also renames QuickstartGrid to `js` instead of `jsx` so that eslint
  picks it up
