### PR TITLE
chore: search icons don't appear on top of header

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/components/SearchInput.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/SearchInput.js
@@ -140,7 +140,6 @@ const SearchInput = forwardRef(
               margin: 0;
               padding: 0;
               outline: none;
-              z-index: 123;
             `}
             type="button"
           >
@@ -176,7 +175,6 @@ const SearchInput = forwardRef(
               margin: 0;
               padding: 0;
               outline: none;
-              z-index: 123;
             `}
             type="button"
           >


### PR DESCRIPTION
this removes a z-index that was causing the search icons to appear over the header when a search term was present and the user scrolled down the page. 

Before:
<img width="1081" alt="Screen Shot 2022-08-17 at 2 37 56 PM" src="https://user-images.githubusercontent.com/47728020/185247889-9e7c2ac6-6903-4502-b4b0-dc780cbbaaab.png">

After:
<img width="1081" alt="Screen Shot 2022-08-17 at 2 37 39 PM" src="https://user-images.githubusercontent.com/47728020/185247904-a6dfeb1d-b319-454b-9e8e-b579d2b74f4f.png">

