### PR TITLE
Add pre tag to markdown component

### DIFF
--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -53,6 +53,22 @@ const h3Tag = (props) => {
     </h6>
   );
 };
+
+const codeblock = (props) => {
+  return (
+    <pre
+      css={css`
+        display: inline-block;
+        padding: 1rem;
+        margin: 0.5rem 0;
+        border-radius: 3px;
+        background: var(--system-background-muted-light);
+      `}
+    >
+      {props.children}
+    </pre>
+  );
+};
 const Markdown = ({ className, ...props }) => (
   <ReactMarkdown
     {...props}
@@ -61,6 +77,7 @@ const Markdown = ({ className, ...props }) => (
       a: aTagToLink,
       h2: h2Tag,
       h3: h3Tag,
+      pre: codeblock,
     }}
   />
 );

--- a/src/components/QuickstartOverview.js
+++ b/src/components/QuickstartOverview.js
@@ -12,6 +12,7 @@ const allowedElements = [
   'ul',
   'li',
   'p',
+  'pre',
   'blockquote',
   'code',
   'a',


### PR DESCRIPTION
We didn't include pre tags in the allowed elements for markdown before so codeblocks didn't render. This adds the tag to the allow list and adds a bit of styling. We actually don't have any codeblocks in quickstart descriptions at the moment (probably because they would disappear before) but here's a screenshot of markdown from an old description:

<img width="1171" alt="Screen Shot 2023-01-09 at 2 41 05 PM" src="https://user-images.githubusercontent.com/39655074/211424377-83899863-ce86-4bf6-8a88-7defe57f0fed.png">
