### PR TITLE
Remove Codestream shift to top

### DIFF
--- a/src/utils/allFilteredQuickstarts.js
+++ b/src/utils/allFilteredQuickstarts.js
@@ -10,23 +10,6 @@ import { rank } from '@utils/searchRanking';
 const alphaSort = (a, b) => a.title.localeCompare(b.title);
 
 /**
- * Callback function for moving codestream to the front of array
- * @param {Object} quickstart node
- * @param {Object} quickstart node
- * @returns {Number}
- */
-const shiftCodestream = (a, b) => {
-  const codestreamId = '29bd9a4a-1c19-4219-9694-0942f6411ce7';
-  if (a.id === codestreamId) {
-    return -1;
-  }
-  if (b.id === codestreamId) {
-    return 1;
-  }
-  return 0;
-};
-
-/**
  * Curried function for filtering by keyword
  * @param {Array} array of quickstarts
  * @param {(Function) => Array} Callback function that filters quickstart array
@@ -90,7 +73,7 @@ const allFilteredQuickstarts = (quickstarts, search, category) => {
   const filterQuickstartsByKeyword = filterQuickstarts(quickstarts);
   const featuredQuickstarts = filterQuickstartsByKeyword('featured');
   const mostPopularQuickstarts = filterQuickstartsByKeyword('most popular');
-  const sortedQuickstarts = quickstarts.sort(alphaSort).sort(shiftCodestream);
+  const sortedQuickstarts = quickstarts.sort(alphaSort);
 
   const filteredQuickstarts = sortedQuickstarts
     .filter(filterBySearch(trimmedSearch))

--- a/src/utils/allFilteredQuickstarts.js
+++ b/src/utils/allFilteredQuickstarts.js
@@ -18,7 +18,7 @@ const alphaSort = (a, b) => a.title.localeCompare(b.title);
 const shiftCodestream = (a, b) => {
   const codestreamId = '29bd9a4a-1c19-4219-9694-0942f6411ce7';
   if (a.id === codestreamId) {
-    return 1;
+    return -1;
   }
   if (b.id === codestreamId) {
     return 1;


### PR DESCRIPTION
This was causing a bug in Firefox that caused the urls that showed on hover of a quickstart to off by one - they still navigate to their correct pages though. 

However after some investigation, we noticed that only Firefox had Codestream being forced to the front of the Quickstarts at all and we learned that the sorting function was the root of this bug. Coincidentally, we think marketing no longer wants Codestream in the front so this has gone unnoticed until now. 

This PR also removes the code that shift codestream to the top. 