### PR TITLE
fix: add optional chaining to support level

### DIFF
--- a/src/utils/preview/parseHelpers.js
+++ b/src/utils/preview/parseHelpers.js
@@ -69,7 +69,7 @@ export const parseQuickstartFiles = (quickstartFiles) => {
   quickstartContent.installPlans = parsedInstallPlans;
   quickstartContent.keywords = loadYaml?.keywords ?? ['Placeholder keyword'];
   quickstartContent.level =
-    loadYaml?.level.replace(' ', '_').toUpperCase() ?? 'COMMUNITY';
+    loadYaml?.level?.replace(' ', '_').toUpperCase() ?? 'COMMUNITY';
   quickstartContent.name = loadYaml?.slug ?? '';
   quickstartContent.packUrl = packUrl ?? '';
   quickstartContent.relatedResources = []; // we don't get these from the config.yml


### PR DESCRIPTION
fixes bug that doesn't load quickstart previews if contributor excludes the `level` key in their config yaml. 

The example PR now loads without redirecting back to the home page:
<img width="1227" alt="Screen Shot 2023-01-12 at 11 34 48 AM" src="https://user-images.githubusercontent.com/47728020/212164128-606d3fad-2f77-4adf-b995-f63ed11612a4.png">
