### PR TITLE
fix: small padding tweak to remove overlapping text

### DIFF
--- a/src/components/GuidedInstallTile.js
+++ b/src/components/GuidedInstallTile.js
@@ -47,7 +47,7 @@ const GuidedInstallTile = () => {
         interactive
         base={Surface.BASE.PRIMARY}
         css={css`
-          padding: 32px;
+          padding: 30px;
           overflow: hidden;
           height: 360px;
           min-width: 250px;
@@ -66,7 +66,7 @@ const GuidedInstallTile = () => {
             'install';
 
           @media screen and (max-width: ${QUICKSTARTS_COLLAPSE_BREAKPOINT}) {
-            padding: 32px 32px 24px 32px;
+            padding: 30px 30px 24px 30px;
             width: 100%;
             min-width: 250px;
           }


### PR DESCRIPTION
BEFORE:

![Screen Shot 2023-01-25 at 4 57 00 PM](https://user-images.githubusercontent.com/26727669/214710997-70716389-57ce-4d95-a547-6243a9614e19.png)

AFTER:

![Screen Shot 2023-01-25 at 4 56 50 PM](https://user-images.githubusercontent.com/26727669/214711001-a8e2cfc3-1197-43d2-86f4-f22183f354ce.png)
