### PR TITLE
NR-102794 MERN stack meta details

### DIFF
--- a/src/data/quickstart-metadata.json
+++ b/src/data/quickstart-metadata.json
@@ -130,5 +130,9 @@
   "snowflake": {
     "title": "Snowflake Performance Monitoring | New Relic",
     "description": "Learn how Snowflake monitoring tool by New Relic helps business users and developers monitor key metrics for credit usage, storage, user history and more."
+  },
+  "mern-stack": {
+    "title": "MERN Stack Performance Monitoring | New Relic",
+    "description": "New Relic's MERN stack integration offers comprehensive monitoring and troubleshooting for MongoDB, Express, React, and Node.js applications in real-time."
   }
 }


### PR DESCRIPTION
Observed that MERN stack is live on the below URL
URL: https://newrelic.com/instant-observability/mern-stack

Hence, I am creating this PR to assign meta title and description to the mern stack quickstart

Ticket: https://issues.newrelic.com/browse/NR-102794
