### PR TITLE
Support data sources as install options

### DIFF
--- a/plugins/gatsby-source-quickstarts/gatsby-node.js
+++ b/plugins/gatsby-source-quickstarts/gatsby-node.js
@@ -57,6 +57,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       alerts: [QuickstartAlertCondition]
       dashboards: [QuickstartDashboard]
       installPlans: [QuickstartInstallPlan]
+      dataSources: [QuickstartDataSource]
     }
 
     type QuickstartDocumentation {
@@ -77,6 +78,11 @@ exports.createSchemaCustomization = ({ actions }) => {
       description: String
       url: String
       screenshots: [File]
+    }
+
+    type QuickstartDataSource {
+      name: String
+      id: String
     }
 
     type QuickstartInstallPlan {
@@ -179,6 +185,7 @@ exports.sourceNodes = async ({
         documentation: quickstart.documentation,
         alerts: quickstart.alerts,
         installPlans: quickstart.installPlans,
+        dataSources: quickstart.dataSources,
         logo: !isLogoSvg ? logoNode : null,
         logoSvg: isLogoSvg ? logoNode : null,
         dashboards,

--- a/scripts/actions/fetch-quickstarts.js
+++ b/scripts/actions/fetch-quickstarts.js
@@ -41,6 +41,12 @@ const nr1CatalogQuickstartQuery = gql`
               icon {
                 url
               }
+              dataSources {
+                id
+                metadata {
+                  displayName
+                }
+              }
               installer {
                 type
                 ... on Nr1CatalogInstallPlan {
@@ -168,7 +174,16 @@ const formatQuickstart = (nr1CatQuickstart) => {
   const installSteps = metadata?.installer?.steps ?? [];
   formatted.installPlans = installSteps.map(formatInstallPlan);
 
+  formatted.dataSources = metadata.dataSources.map(formatDataSource);
+
   return formatted;
+};
+
+const formatDataSource = (nr1CatDataSource) => {
+  return {
+    id: nr1CatDataSource.id,
+    name: nr1CatDataSource.metadata.displayName,
+  };
 };
 
 const formatDashboard = (nr1CatDashboard) => {

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -93,6 +93,7 @@ const InstallButton = ({
 
   const hasInstallableComponent =
     hasComponent(quickstart, 'installPlans') ||
+    hasComponent(quickstart, 'dataSources') ||
     quickstart.id === CODESTREAM_QUICKSTART_ID;
 
   const tessen = useTessen();
@@ -214,6 +215,10 @@ InstallButton.propTypes = {
 export const fragmentQuery = graphql`
   fragment InstallButton_quickstart on Quickstarts {
     installPlans {
+      id
+      name
+    }
+    dataSources {
       id
       name
     }


### PR DESCRIPTION
# Summary

Adds data sources into the query that pulls quickstarts from Nerdgraph. Also updates the install button to head into the production when a quickstart has data sources, but no install plans.
